### PR TITLE
Add problem details to DataCoreHttpClientException

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 1,
-  "Minor": 0,
-  "Patch": 3,
+  "Minor": 1,
+  "Patch": 0,
   "PreRelease": ""
 }

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 1,
   "Minor": 0,
-  "Patch": 2,
+  "Patch": 3,
   "PreRelease": ""
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientException.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientException.cs
@@ -192,7 +192,9 @@ namespace IntelligentPlant.DataCore.Client {
                 : null;
 
             return new DataCoreHttpClientException(
-                errorMessage, 
+                problemDetails == null
+                    ? errorMessage
+                    : string.Concat(errorMessage, " ", Resources.Error_SeeProblemDetails), 
                 response.RequestMessage.Method.Method, 
                 response.RequestMessage.RequestUri.ToString(), 
                 response.StatusCode, 

--- a/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientException.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientException.cs
@@ -39,9 +39,16 @@ namespace IntelligentPlant.DataCore.Client {
         public IDictionary<string, string[]> ResponseHeaders { get; }
 
         /// <summary>
-        /// Gets the response content that was returned
+        /// Gets the response content that was returned.
         /// </summary>
         public string Content { get; }
+
+        /// <summary>
+        /// The RFC 7807 problem details object that was returned in the response body. This will 
+        /// be <see langword="null"/> unless the content type of the response was 
+        /// <see cref="ProblemDetails.Constants.MediaType"/>.
+        /// </summary>
+        public ProblemDetails.ProblemDetails ProblemDetails { get; }
 
 
         /// <summary>
@@ -68,8 +75,11 @@ namespace IntelligentPlant.DataCore.Client {
         /// <param name="responseContent">
         ///   The response content.
         /// </param>
-        public DataCoreHttpClientException(string message, string verb, string url, HttpStatusCode statusCode, IDictionary<string, string[]> requestHeaders, IDictionary<string, string[]> responseHeaders, string responseContent) 
-            : this(message, verb, url, statusCode, requestHeaders, responseHeaders, responseContent, null) { }
+        /// <param name="problemDetails">
+        ///   The RFC 7807 problem details object describing the error.
+        /// </param>
+        public DataCoreHttpClientException(string message, string verb, string url, HttpStatusCode statusCode, IDictionary<string, string[]> requestHeaders, IDictionary<string, string[]> responseHeaders, string responseContent, ProblemDetails.ProblemDetails problemDetails) 
+            : this(message, verb, url, statusCode, requestHeaders, responseHeaders, responseContent, problemDetails, null) { }
 
 
         /// <summary>
@@ -96,10 +106,13 @@ namespace IntelligentPlant.DataCore.Client {
         /// <param name="responseContent">
         ///   The response content.
         /// </param>
+        /// <param name="problemDetails">
+        ///   The RFC 7807 problem details object describing the error.
+        /// </param>
         /// <param name="inner">
         ///   The inner exception.
         /// </param>
-        public DataCoreHttpClientException(string message, string verb, string url, HttpStatusCode statusCode, IDictionary<string, string[]> requestHeaders, IDictionary<string, string[]> responseHeaders, string responseContent, Exception inner) 
+        public DataCoreHttpClientException(string message, string verb, string url, HttpStatusCode statusCode, IDictionary<string, string[]> requestHeaders, IDictionary<string, string[]> responseHeaders, string responseContent, ProblemDetails.ProblemDetails problemDetails, Exception inner) 
             : base(message, inner) {
             Verb = verb;
             Url = url;
@@ -107,31 +120,52 @@ namespace IntelligentPlant.DataCore.Client {
             RequestHeaders = new ReadOnlyDictionary<string, string[]>(requestHeaders ?? new Dictionary<string, string[]>());
             ResponseHeaders = new ReadOnlyDictionary<string, string[]>(responseHeaders ?? new Dictionary<string, string[]>());
             Content = responseContent;
+            ProblemDetails = problemDetails;
         }
 
 
         /// <summary>
-        /// Creates an <see cref="DataCoreHttpClientException"/> using the specified HTTP response message.
+        /// Creates an <see cref="DataCoreHttpClientException"/> using the specified HTTP response 
+        /// message.
         /// </summary>
-        /// <param name="errorMessage">The error message.</param>
-        /// <param name="response">The HTTP response.</param>
+        /// <param name="errorMessage">
+        ///   The error message.
+        /// </param>
+        /// <param name="response">
+        ///   The HTTP response.
+        /// </param>
         /// <returns>
         /// A task that will return the exception.
         /// </returns>
+        /// <remarks>
+        ///   If the response contains an RFC 7807 problem details object, the <see cref="ProblemDetails"/> 
+        ///   property of the exception will be set.
+        /// </remarks>
         internal static Task<DataCoreHttpClientException> FromHttpResponseMessage(string errorMessage, HttpResponseMessage response) {
             return FromHttpResponseMessage(errorMessage, response, null);
         }
 
 
         /// <summary>
-        /// Creates an <see cref="DataCoreHttpClientException"/> with an inner exception, using the specified HTTP response message.
+        /// Creates an <see cref="DataCoreHttpClientException"/> with an inner exception, using 
+        /// the specified HTTP response message.
         /// </summary>
-        /// <param name="errorMessage">The error message.</param>
-        /// <param name="response">The HTTP response.</param>
-        /// <param name="inner">The inner exception</param>
+        /// <param name="errorMessage">
+        ///   The error message.
+        /// </param>
+        /// <param name="response">
+        ///   The HTTP response.
+        /// </param>
+        /// <param name="inner">
+        ///   The inner exception.
+        /// </param>
         /// <returns>
         /// A task that will return the exception.
         /// </returns>
+        /// <remarks>
+        ///   If the response contains an RFC 7807 problem details object, the <see cref="ProblemDetails"/> 
+        ///   property of the exception will be set.
+        /// </remarks>
         internal static async Task<DataCoreHttpClientException> FromHttpResponseMessage(string errorMessage, HttpResponseMessage response, Exception inner) {
             if (response == null) {
                 throw new ArgumentNullException(nameof(response));
@@ -146,11 +180,15 @@ namespace IntelligentPlant.DataCore.Client {
                 : response.Headers.Concat(response.Content.Headers).ToDictionary(x => x.Key, x => x.Value.ToArray());
 
             var includeContent = responseHeaders.TryGetValue("Content-Type", out var contentTypes) && contentTypes != null
-                ? contentTypes.Any(x => CanIncludeContent(x))
+                ? contentTypes.Any(CanIncludeContent)
                 : false;
 
             var content = includeContent
                 ? await response.Content.ReadAsStringAsync().ConfigureAwait(false)
+                : null;
+
+            var problemDetails = includeContent && contentTypes.Any(IsProblemDetailsResponse)
+                ? Newtonsoft.Json.JsonConvert.DeserializeObject<ProblemDetails.ProblemDetails>(content)
                 : null;
 
             return new DataCoreHttpClientException(
@@ -161,8 +199,24 @@ namespace IntelligentPlant.DataCore.Client {
                 requestHeaders,
                 responseHeaders,
                 content, 
+                problemDetails,
                 inner
             );
+        }
+
+
+        /// <summary>
+        /// Tests if the specified content type represents an RFC 7807 response.
+        /// </summary>
+        /// <param name="contentType">
+        ///   The content type.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> if the content type is an RFC 7807 object, or <see langword="false"/> 
+        ///   otherwise.
+        /// </returns>
+        private static bool IsProblemDetailsResponse(string contentType) {
+            return contentType.StartsWith(IntelligentPlant.ProblemDetails.Constants.MediaType);
         }
 
 
@@ -180,6 +234,9 @@ namespace IntelligentPlant.DataCore.Client {
         private static bool CanIncludeContent(string contentType) {
             if (string.IsNullOrWhiteSpace(contentType)) {
                 return false;
+            }
+            if (IsProblemDetailsResponse(contentType)) {
+                return true;
             }
             if (contentType.StartsWith("application/json")) {
                 return true;

--- a/src/IntelligentPlant.DataCore.HttpClient/IntelligentPlant.DataCore.HttpClient.csproj
+++ b/src/IntelligentPlant.DataCore.HttpClient/IntelligentPlant.DataCore.HttpClient.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="IntelligentPlant.ProblemDetails.Core" Version="3.0.0" />
     <PackageReference Include="IntelligentPlant.Relativity" Version="1.0.0" />
     <PackageReference Include="Jaahas.HttpRequestTransformer" Version="1.0.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />

--- a/src/IntelligentPlant.DataCore.HttpClient/Resources.Designer.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Resources.Designer.cs
@@ -79,7 +79,7 @@ namespace IntelligentPlant.DataCore.Client {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A non-good status code was returned: {0} {1} {2}/{3}.
+        ///   Looks up a localized string similar to A non-good status code was returned: {0} {1} {2}/{3}..
         /// </summary>
         internal static string Error_DefaultHttpErrorMessage {
             get {
@@ -390,6 +390,15 @@ namespace IntelligentPlant.DataCore.Client {
         internal static string Error_Scripting_TooManyTagReferences {
             get {
                 return ResourceManager.GetString("Error_Scripting_TooManyTagReferences", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;ProblemDetails&apos; property on the exception contains the RFC 7807 response received from the server..
+        /// </summary>
+        internal static string Error_SeeProblemDetails {
+            get {
+                return ResourceManager.GetString("Error_SeeProblemDetails", resourceCulture);
             }
         }
         

--- a/src/IntelligentPlant.DataCore.HttpClient/Resources.resx
+++ b/src/IntelligentPlant.DataCore.HttpClient/Resources.resx
@@ -124,7 +124,7 @@
     <value>A data source name is required.</value>
   </data>
   <data name="Error_DefaultHttpErrorMessage" xml:space="preserve">
-    <value>A non-good status code was returned: {0} {1} {2}/{3}</value>
+    <value>A non-good status code was returned: {0} {1} {2}/{3}.</value>
     <comment>{0} - HTTP verb
 {1} - URL
 {2} - status code
@@ -247,6 +247,9 @@
   <data name="Error_Scripting_TooManyTagReferences" xml:space="preserve">
     <value>Maximum number of tag references is {0}.</value>
     <comment>{0} - limit</comment>
+  </data>
+  <data name="Error_SeeProblemDetails" xml:space="preserve">
+    <value>The 'ProblemDetails' property on the exception contains the RFC 7807 response received from the server.</value>
   </data>
   <data name="Error_StartTimeCannotBeGreaterThanEndTime" xml:space="preserve">
     <value>Start time cannot be greater than end time.</value>


### PR DESCRIPTION
When an API call returns a non-good response containing an RFC 7807 problem details object, this content will be deserialized and added to a new `ProblemDetails` property on the `DataCoreHttpClientException` type.