### PR TITLE
Add template for hosted App Store Connect adapter

### DIFF
--- a/IntelligentPlant.IndustrialAppStore.ClientTools.sln
+++ b/IntelligentPlant.IndustrialAppStore.ClientTools.sln
@@ -62,6 +62,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "data-core-api-client", "dat
 		docs\data-core-api-client\Writing-Tag-Values.md = docs\data-core-api-client\Writing-Tag-Values.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExampleHostedAdapter", "samples\ExampleHostedAdapter\ExampleHostedAdapter.csproj", "{419B0B14-84DD-4FB0-9164-D12199C6931D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -92,6 +94,10 @@ Global
 		{05B5BBD1-19CF-43F5-A7CB-02831D20783B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{05B5BBD1-19CF-43F5-A7CB-02831D20783B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{05B5BBD1-19CF-43F5-A7CB-02831D20783B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{419B0B14-84DD-4FB0-9164-D12199C6931D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{419B0B14-84DD-4FB0-9164-D12199C6931D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{419B0B14-84DD-4FB0-9164-D12199C6931D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{419B0B14-84DD-4FB0-9164-D12199C6931D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -104,6 +110,7 @@ Global
 		{83C9EAEA-E7D7-42AF-BA17-63CD63568A70} = {49E8C063-F41F-451F-81BF-C4960B9A0168}
 		{05B5BBD1-19CF-43F5-A7CB-02831D20783B} = {65FE3E10-29B7-4A78-9ED8-C8384AE9D420}
 		{B394A8BF-92A8-46B8-B703-C8D398DAF61E} = {34009963-21E6-4DBE-ADF8-FE005C4FC279}
+		{419B0B14-84DD-4FB0-9164-D12199C6931D} = {65FE3E10-29B7-4A78-9ED8-C8384AE9D420}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D12472DA-7354-4A19-8F60-4F9D42C71241}

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 1,
-  "Minor": 2,
-  "Patch": 1,
+  "Minor": 3,
+  "Patch": 0,
   "PreRelease": ""
 }

--- a/samples/ExampleAdapter/ExampleAdapter.csproj
+++ b/samples/ExampleAdapter/ExampleAdapter.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter" Version="1.0.2" />
+    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/ExampleAdapter/MyAdapter.cs
+++ b/samples/ExampleAdapter/MyAdapter.cs
@@ -9,11 +9,25 @@ using IntelligentPlant.BackgroundTasks;
 
 using Microsoft.Extensions.Logging;
 
+// The [VendorInfo] attribute is used to add vendor information to all adapters in this assembly.
+[assembly: VendorInfo("My Company", "https://my-company.com")]
+
 namespace ExampleAdapter {
 
     // This is your adapter class. For information about how to add features to your adapter (such 
     // as tag browsing, or real-time data queries), visit https://github.com/intelligentplant/AppStoreConnect.Adapters.
 
+    // The [AdapterMetadata] attribute is used to provide information about your adapter type at
+    // runtime.
+    [AdapterMetadata(
+        // This is a URI to identify the adapter type; it is not required that the URI can be
+        // dereferenced!
+        "https://my-company.com/app-store-connect/adapters/my-adapter/",
+        // The display name for the adapter type.
+        Name = "My Adapter",
+        // The adapter type description.
+        Description = "A brief description of the adapter type"
+    )]
     public class MyAdapter : AdapterBase<MyAdapterOptions> {
 
         public MyAdapter(
@@ -22,25 +36,6 @@ namespace ExampleAdapter {
             IBackgroundTaskService taskScheduler,
             ILogger<MyAdapter> logger
         ) : base(id, options, taskScheduler, logger) {  }
-
-
-        // This constructor allows your adapter to respond to configuration changes at runtime. 
-        // See the OnOptionsChange method below. You can remove this constructor if you do not 
-        // require this capability.
-        public MyAdapter(
-            string id,
-            IAdapterOptionsMonitor<MyAdapterOptions> options,
-            IBackgroundTaskService taskScheduler,
-            ILogger<MyAdapter> logger
-        ) : base(id, options, taskScheduler, logger) { }
-
-
-        // If the adapter is created using the IAdapterOptionsMonitor<T> overload above, the 
-        // OnOptionsChange method will be called whenever the adapter's configuration options are 
-        // changed once the adapter has started. You can remove this override if it is not required.
-        protected override void OnOptionsChange(MyAdapterOptions options) {
-            base.OnOptionsChange(options);
-        }
 
 
         // The StartAsync method is called when the adapter is being started up. Use this method to 
@@ -60,7 +55,7 @@ namespace ExampleAdapter {
         }
 
 
-        // Implement the CheckHealthAsync method to add custom health checks to your adapter. 
+        // Override the CheckHealthAsync method to add custom health checks to your adapter. 
         // Health checks allow you to report on the status of e.g. connections to external 
         // systems. If you detect that the underlying health status of the adapter has changed 
         // (e.g. you unexpectedly disconnect from an external system) you can notify the base 

--- a/samples/ExampleHostedAdapter/ExampleHostedAdapter.ReadSnapshotTagValues.cs
+++ b/samples/ExampleHostedAdapter/ExampleHostedAdapter.ReadSnapshotTagValues.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter;
+using DataCore.Adapter.RealTimeData;
+
+namespace ExampleHostedAdapter {
+
+    // This file implements the IReadSnapshotTagValues adapter feature, which allows tags to be
+    // polled for their current value.
+    //
+    // See https://github.com/intelligentplant/AppStoreConnect.Adapters for more details.
+
+    partial class ExampleHostedAdapter : IReadSnapshotTagValues {
+        public async IAsyncEnumerable<TagValueQueryResult> ReadSnapshotTagValues(
+            IAdapterCallContext context, 
+            ReadSnapshotTagValuesRequest request, 
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            ValidateInvocation(context, request);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+
+            var now = DateTime.UtcNow;
+
+            Random GetRng(string tagId) {
+                return new Random((tagId.GetHashCode() + now.GetHashCode()).GetHashCode());
+            }
+
+            using (var ctSource = CreateCancellationTokenSource(cancellationToken)) {
+                foreach (var tag in request.Tags) {
+                    if (ctSource.IsCancellationRequested) {
+                        break;
+                    }
+
+                    if (!TryGetTagByIdOrName(tag, out var tagDef)) {
+                        continue;
+                    }
+
+                    var rnd = GetRng(tagDef.Id);
+
+                    var value = new TagValueBuilder().WithUtcSampleTime(now).WithValue(rnd.NextDouble() * 100).Build();
+                    yield return new TagValueQueryResult(tagDef.Id, tagDef.Name, value);
+                }
+            }
+        }
+    }
+}

--- a/samples/ExampleHostedAdapter/ExampleHostedAdapter.TagSearch.cs
+++ b/samples/ExampleHostedAdapter/ExampleHostedAdapter.TagSearch.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter;
+using DataCore.Adapter.Common;
+using DataCore.Adapter.Tags;
+
+namespace ExampleHostedAdapter {
+
+    // This file implements the ITagSearch adapter feature, meaning that our adapter allows
+    // callers to discover available tags (measurements) that can be read. In our example we use a
+    // fixed set of tags created at startup time, but your implementation might e.g. query a
+    // database to get a list of available measurements.
+    //
+    // See https://github.com/intelligentplant/AppStoreConnect.Adapters for more details.
+
+    partial class ExampleHostedAdapter : ITagSearch {
+
+        private static readonly AdapterProperty s_tagCreatedAtPropertyDefinition = new AdapterProperty("UtcCreatedAt", DateTime.MinValue, "The UTC creation time for the tag");
+
+        private static readonly AdapterProperty[] s_tagPropertyDefinitions = {
+            s_tagCreatedAtPropertyDefinition
+        };
+
+        private readonly ConcurrentDictionary<string, TagDefinition> _tags = new ConcurrentDictionary<string, TagDefinition>(StringComparer.OrdinalIgnoreCase) { 
+            ["test"] = new TagDefinitionBuilder("test", "Test Tag")
+                .WithDescription("An example tag that can be polled for snapshot (current) values.")
+                .WithDataType(VariantType.Double)
+                .WithSupportsReadSnapshotValues()
+                .WithProperty(s_tagCreatedAtPropertyDefinition.Name, DateTime.UtcNow)
+                .Build()
+        };
+
+
+        private bool TryGetTagByIdOrName(string tagIdOrName, out TagDefinition tag) {
+            if (_tags.TryGetValue(tagIdOrName, out tag)) {
+                return true;
+            }
+
+            tag = _tags.Values.FirstOrDefault(x => string.Equals(x.Name, tagIdOrName, StringComparison.OrdinalIgnoreCase));
+            return tag != null;
+        }
+
+
+        public async IAsyncEnumerable<AdapterProperty> GetTagProperties(
+            IAdapterCallContext context, 
+            GetTagPropertiesRequest request, 
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            ValidateInvocation(context, request);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+
+            using (var ctSource = CreateCancellationTokenSource(cancellationToken)) {
+                foreach (var prop in s_tagPropertyDefinitions.OrderBy(x => x.Name).SelectPage(request)) {
+                    if (ctSource.IsCancellationRequested) {
+                        break;
+                    }
+                    yield return prop;
+                }
+            }
+        }
+
+
+        public async IAsyncEnumerable<TagDefinition> GetTags(
+            IAdapterCallContext context, 
+            GetTagsRequest request, 
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            ValidateInvocation(context, request);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+
+            using (var ctSource = CreateCancellationTokenSource(cancellationToken)) {
+                foreach (var tag in request.Tags) {
+                    if (ctSource.IsCancellationRequested) {
+                        break;
+                    }
+
+                    if (!TryGetTagByIdOrName(tag, out var tagDef)) {
+                        continue;
+                    }
+
+                    yield return tagDef;
+                }
+            }
+        }
+
+
+        public async IAsyncEnumerable<TagDefinition> FindTags(
+            IAdapterCallContext context, 
+            FindTagsRequest request, 
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            ValidateInvocation(context, request);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+
+            using (var ctSource = CreateCancellationTokenSource(cancellationToken)) {
+                foreach (var tagDef in _tags.Values.ApplyFilter(request)) {
+                    if (ctSource.IsCancellationRequested) {
+                        break;
+                    }
+
+                    yield return tagDef;
+                }
+            }
+        }
+
+        
+    }
+}

--- a/samples/ExampleHostedAdapter/ExampleHostedAdapter.cs
+++ b/samples/ExampleHostedAdapter/ExampleHostedAdapter.cs
@@ -8,11 +8,12 @@ using DataCore.Adapter.Diagnostics;
 using IntelligentPlant.BackgroundTasks;
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 // The [VendorInfo] attribute is used to add vendor information to all adapters in this assembly.
 [assembly: VendorInfo("My Company", "https://my-company.com")]
 
-namespace ExampleAdapter {
+namespace ExampleHostedAdapter {
 
     // This is your adapter class. For information about how to add features to your adapter (such 
     // as tag browsing, or real-time data queries), visit https://github.com/intelligentplant/AppStoreConnect.Adapters.
@@ -28,14 +29,14 @@ namespace ExampleAdapter {
         // The adapter type description.
         Description = "A brief description of the adapter type"
     )]
-    public class MyAdapter : AdapterBase<MyAdapterOptions> {
+    public partial class ExampleHostedAdapter : AdapterBase<ExampleHostedAdapterOptions> {
 
-        public MyAdapter(
-            string id,
-            MyAdapterOptions options,
+        public ExampleHostedAdapter(
+            string id, 
+            IOptionsMonitor<ExampleHostedAdapterOptions> options,
             IBackgroundTaskService taskScheduler,
-            ILogger<MyAdapter> logger
-        ) : base(id, options, taskScheduler, logger) { }
+            ILogger<ExampleHostedAdapter> logger
+        ) : base(id, options, taskScheduler, logger) {  }
 
 
         // The StartAsync method is called when the adapter is being started up. Use this method to 
@@ -55,6 +56,15 @@ namespace ExampleAdapter {
         }
 
 
+        // The OnOptionsChange method is called every time the adapter receives an update to its
+        // options at runtime. You can use this method to trigger any runtime changes required.
+        // You can test this functionality by running the application and then changing the
+        // adapter name or description in appsettings.json at runtime.
+        protected override void OnOptionsChange(ExampleHostedAdapterOptions options) {
+            base.OnOptionsChange(options);
+        }
+
+
         // Override the CheckHealthAsync method to add custom health checks to your adapter. 
         // Health checks allow you to report on the status of e.g. connections to external 
         // systems. If you detect that the underlying health status of the adapter has changed 
@@ -62,7 +72,7 @@ namespace ExampleAdapter {
         // class that the overall health status must be recalculated by calling the 
         // OnHealthStatusChanged method.
         protected override async Task<IEnumerable<HealthCheckResult>> CheckHealthAsync(
-            IAdapterCallContext context,
+            IAdapterCallContext context, 
             CancellationToken cancellationToken
         ) {
             var result = new List<HealthCheckResult>();

--- a/samples/ExampleHostedAdapter/ExampleHostedAdapter.csproj
+++ b/samples/ExampleHostedAdapter/ExampleHostedAdapter.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter" Version="2.0.0" />
+    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.Grpc" Version="2.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc3" />
+  </ItemGroup>
+  
+</Project>

--- a/samples/ExampleHostedAdapter/ExampleHostedAdapterOptions.cs
+++ b/samples/ExampleHostedAdapter/ExampleHostedAdapterOptions.cs
@@ -1,0 +1,14 @@
+﻿using DataCore.Adapter;
+
+namespace ExampleHostedAdapter {
+
+    // This class defines the runtime options used to configure your adapter.
+
+    public class ExampleHostedAdapterOptions : AdapterOptions {
+
+        // Add properties required to configure your adapter e.g. connection endpoints, 
+        // credentials, etc. The Startup.cs file is configured to bind adapter options
+        // via the app configuration (e.g. appsettings.json).
+
+    }
+}

--- a/samples/ExampleHostedAdapter/Program.cs
+++ b/samples/ExampleHostedAdapter/Program.cs
@@ -1,0 +1,17 @@
+﻿
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace ExampleHostedAdapter {
+    public class Program {
+        public static void Main(string[] args) {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder => {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/samples/ExampleHostedAdapter/Properties/launchSettings.json
+++ b/samples/ExampleHostedAdapter/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "profiles": {
+    "ExampleAdapterHost": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:44368",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/ExampleHostedAdapter/Startup.cs
+++ b/samples/ExampleHostedAdapter/Startup.cs
@@ -1,0 +1,109 @@
+﻿using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace ExampleHostedAdapter {
+    public class Startup {
+
+        // Our adapter instance will use this ID at runtime.
+        public const string AdapterId = "fdb421d7-03b2-49e8-880a-224e8e5f04ef";
+
+
+        public IConfiguration Configuration { get; }
+
+
+        public Startup(IConfiguration configuration) {
+            Configuration = configuration;
+        }
+
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services) {
+            // Add adapter services
+
+            var version = GetType().Assembly.GetName().Version.ToString(3);
+
+            services
+                .AddDataCoreAdapterAspNetCoreServices()
+                .AddHostInfo("ExampleHostedAdapter Host", "A host application for an App Store Connect adapter")
+                .AddServices(svc => {
+                    // Bind adapter options against the application configuration.
+                    svc.Configure<ExampleHostedAdapterOptions>(AdapterId, Configuration.GetSection($"AppStoreConnect:Settings:{AdapterId}"));
+                })
+                // Register our adapter with the DI container. The AdapterId parameter will be
+                // used as the adapter ID.
+                .AddAdapter(sp => ActivatorUtilities.CreateInstance<ExampleHostedAdapter>(sp, AdapterId));
+            //.AddAdapterFeatureAuthorization<MyAdapterFeatureAuthHandler>();
+
+            // To add authentication and authorization for adapter API operations, extend 
+            // the FeatureAuthorizationHandler class and call AddAdapterFeatureAuthorization
+            // above to register your handler.
+
+            services.AddGrpc();
+
+            services.AddMvc()
+                .SetCompatibilityVersion(CompatibilityVersion.Latest)
+                .AddJsonOptions(options => {
+                    options.JsonSerializerOptions.WriteIndented = true;
+                })
+                .AddDataCoreAdapterMvc();
+
+            // Add OpenTelemetry tracing
+            services.AddOpenTelemetryTracing(builder => {
+                builder
+                    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(
+                        "IAS Adapter Host",
+                        serviceVersion: version,
+                        serviceInstanceId: AdapterId
+                    ))
+                    // Use AddConsoleExporter() to export to stdout. 
+                    //.AddConsoleExporter()    
+                    // Use AddJaegerExporter() to export to Jaeger (https://www.jaegertracing.io/).
+                    //.AddJaegerExporter() 
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddSqlClientInstrumentation()
+                    .AddDataCoreAdapterInstrumentation();
+            });
+        }
+
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
+            if (env.IsDevelopment()) {
+                app.UseDeveloperExceptionPage();
+            }
+            else {
+                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRequestLocalization();
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints => {
+                // Map MVC API and gRPC endpoints.
+                endpoints.MapControllers();
+                endpoints.MapDataCoreGrpcServices();
+
+                // Redirect requests to / to the API endpoint for retrieving details about the
+                // adapter.
+                endpoints.MapGet("/", context => {
+                    context.Response.Redirect($"/api/app-store-connect/v2.0/adapters/{AdapterId}");
+                    return Task.CompletedTask;
+                });
+            });
+        }
+    }
+}

--- a/samples/ExampleHostedAdapter/appsettings.Development.json
+++ b/samples/ExampleHostedAdapter/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/samples/ExampleHostedAdapter/appsettings.json
+++ b/samples/ExampleHostedAdapter/appsettings.json
@@ -1,0 +1,23 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http1AndHttp2"
+    }
+  },
+  "AppStoreConnect": {
+    "Settings": {
+      "fdb421d7-03b2-49e8-880a-224e8e5f04ef": {
+        "Name": "My Example Adapter",
+        "Description": "An example adapter generated using a template."
+      }
+    }
+  }
+}

--- a/samples/ExampleHostedAdapter/appsettings.json
+++ b/samples/ExampleHostedAdapter/appsettings.json
@@ -10,6 +10,11 @@
   "Kestrel": {
     "EndpointDefaults": {
       "Protocols": "Http1AndHttp2"
+    },
+    "Endpoints": {
+      "Https": {
+        "Url": "https://localhost:44368"
+      }
     }
   },
   "AppStoreConnect": {

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/IntelligentPlant.IndustrialAppStore.Templates.csproj
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/IntelligentPlant.IndustrialAppStore.Templates.csproj
@@ -22,10 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="templates\iasmvc\ExampleMvcApplication.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="ExampleMvcApplication.csproj.in">
       <DependentUpon>templates\iasmvc\ExampleMvcApplication.csproj</DependentUpon>
     </None>

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasadapter/ExampleAdapter.csproj
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasadapter/ExampleAdapter.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter" Version="1.0.2" />
+    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/.template.config/dotnetcli.host.json
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/.template.config/dotnetcli.host.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "HttpsPort": {
+      "longName": "port",
+      "shortName": ""
+    },
+    "SkipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  },
+  "usageExamples": []
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/.template.config/template.json
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/.template.config/template.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Intelligent Plant",
+  "classifications": [ "Industrial App Store", "Web", "MVC" ],
+  "identity": "IntelligentPlant.IndustrialAppStore.AppStoreConnectAdapterHost",
+  "name": "Industrial App Store ASP.NET Core Adapter Host",
+  "shortName": "iasadapterhost",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "ExampleHostedAdapter",
+  "preferNameDirectory": true,
+  "guids": [
+    "fdb421d7-03b2-49e8-880a-224e8e5f04ef"
+  ],
+  "symbols": {
+    "AdapterOptionsName": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "AppendOptionsSuffix",
+      "replaces": "ExampleHostedAdapterOptions",
+      "fileRename": "ExampleHostedAdapterOptions"
+    },
+    "HttpsPort": {
+      "type": "parameter",
+      "datatype": "integer",
+      "description": "Port number to use for the HTTPS endpoint in launchSettings.json. If not specified, a port number will be generated automatically."
+    },
+    "SkipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    },
+    "HttpPortGenerated": {
+      "type": "generated",
+      "generator": "port"
+    },
+    "HttpPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpPortGenerated",
+        "fallbackVariableName": "HttpPortGenerated"
+      },
+      "replaces": "8080"
+    },
+    "HttpsPortGenerated": {
+      "type": "generated",
+      "generator": "port",
+      "parameters": {
+        "low": 44300,
+        "high": 44399
+      }
+    },
+    "HttpsPortReplacer": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "HttpsPort",
+        "fallbackVariableName": "HttpsPortGenerated"
+      },
+      "replaces": "44300"
+    }
+  },
+  "forms": {
+    "AppendOptionsSuffix": {
+      "identifier": "replace",
+      "pattern": "^(.+)$",
+      "replacement": "$1Options"
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "ExampleHostedAdapter.csproj"
+    }
+  ],
+  "defaultName": "IasHostedAdapter",
+  "postActions": [
+    {
+      "condition": "(!SkipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        { "text": "Run 'dotnet restore'" }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/ExampleHostedAdapter.ReadSnapshotTagValues.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/ExampleHostedAdapter.ReadSnapshotTagValues.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter;
+using DataCore.Adapter.RealTimeData;
+
+namespace ExampleHostedAdapter {
+
+    // This file implements the IReadSnapshotTagValues adapter feature, which allows tags to be
+    // polled for their current value.
+    //
+    // See https://github.com/intelligentplant/AppStoreConnect.Adapters for more details.
+
+    partial class ExampleHostedAdapter : IReadSnapshotTagValues {
+        public async IAsyncEnumerable<TagValueQueryResult> ReadSnapshotTagValues(
+            IAdapterCallContext context, 
+            ReadSnapshotTagValuesRequest request, 
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            ValidateInvocation(context, request);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+
+            var now = DateTime.UtcNow;
+
+            Random GetRng(string tagId) {
+                return new Random((tagId.GetHashCode() + now.GetHashCode()).GetHashCode());
+            }
+
+            using (var ctSource = CreateCancellationTokenSource(cancellationToken)) {
+                foreach (var tag in request.Tags) {
+                    if (ctSource.IsCancellationRequested) {
+                        break;
+                    }
+
+                    if (!TryGetTagByIdOrName(tag, out var tagDef)) {
+                        continue;
+                    }
+
+                    var rnd = GetRng(tagDef.Id);
+
+                    var value = new TagValueBuilder().WithUtcSampleTime(now).WithValue(rnd.NextDouble() * 100).Build();
+                    yield return new TagValueQueryResult(tagDef.Id, tagDef.Name, value);
+                }
+            }
+        }
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/ExampleHostedAdapter.TagSearch.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/ExampleHostedAdapter.TagSearch.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using DataCore.Adapter;
+using DataCore.Adapter.Common;
+using DataCore.Adapter.Tags;
+
+namespace ExampleHostedAdapter {
+
+    // This file implements the ITagSearch adapter feature, meaning that our adapter allows
+    // callers to discover available tags (measurements) that can be read. In our example we use a
+    // fixed set of tags created at startup time, but your implementation might e.g. query a
+    // database to get a list of available measurements.
+    //
+    // See https://github.com/intelligentplant/AppStoreConnect.Adapters for more details.
+
+    partial class ExampleHostedAdapter : ITagSearch {
+
+        private static readonly AdapterProperty s_tagCreatedAtPropertyDefinition = new AdapterProperty("UtcCreatedAt", DateTime.MinValue, "The UTC creation time for the tag");
+
+        private static readonly AdapterProperty[] s_tagPropertyDefinitions = {
+            s_tagCreatedAtPropertyDefinition
+        };
+
+        private readonly ConcurrentDictionary<string, TagDefinition> _tags = new ConcurrentDictionary<string, TagDefinition>(StringComparer.OrdinalIgnoreCase) { 
+            ["test"] = new TagDefinitionBuilder("test", "Test Tag")
+                .WithDescription("An example tag that can be polled for snapshot (current) values.")
+                .WithDataType(VariantType.Double)
+                .WithSupportsReadSnapshotValues()
+                .WithProperty(s_tagCreatedAtPropertyDefinition.Name, DateTime.UtcNow)
+                .Build()
+        };
+
+
+        private bool TryGetTagByIdOrName(string tagIdOrName, out TagDefinition tag) {
+            if (_tags.TryGetValue(tagIdOrName, out tag)) {
+                return true;
+            }
+
+            tag = _tags.Values.FirstOrDefault(x => string.Equals(x.Name, tagIdOrName, StringComparison.OrdinalIgnoreCase));
+            return tag != null;
+        }
+
+
+        public async IAsyncEnumerable<AdapterProperty> GetTagProperties(
+            IAdapterCallContext context, 
+            GetTagPropertiesRequest request, 
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            ValidateInvocation(context, request);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+
+            using (var ctSource = CreateCancellationTokenSource(cancellationToken)) {
+                foreach (var prop in s_tagPropertyDefinitions.OrderBy(x => x.Name).SelectPage(request)) {
+                    if (ctSource.IsCancellationRequested) {
+                        break;
+                    }
+                    yield return prop;
+                }
+            }
+        }
+
+
+        public async IAsyncEnumerable<TagDefinition> GetTags(
+            IAdapterCallContext context, 
+            GetTagsRequest request, 
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            ValidateInvocation(context, request);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+
+            using (var ctSource = CreateCancellationTokenSource(cancellationToken)) {
+                foreach (var tag in request.Tags) {
+                    if (ctSource.IsCancellationRequested) {
+                        break;
+                    }
+
+                    if (!TryGetTagByIdOrName(tag, out var tagDef)) {
+                        continue;
+                    }
+
+                    yield return tagDef;
+                }
+            }
+        }
+
+
+        public async IAsyncEnumerable<TagDefinition> FindTags(
+            IAdapterCallContext context, 
+            FindTagsRequest request, 
+            [EnumeratorCancellation]
+            CancellationToken cancellationToken
+        ) {
+            ValidateInvocation(context, request);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+
+            using (var ctSource = CreateCancellationTokenSource(cancellationToken)) {
+                foreach (var tagDef in _tags.Values.ApplyFilter(request)) {
+                    if (ctSource.IsCancellationRequested) {
+                        break;
+                    }
+
+                    yield return tagDef;
+                }
+            }
+        }
+
+        
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/ExampleHostedAdapter.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/ExampleHostedAdapter.cs
@@ -8,11 +8,12 @@ using DataCore.Adapter.Diagnostics;
 using IntelligentPlant.BackgroundTasks;
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 // The [VendorInfo] attribute is used to add vendor information to all adapters in this assembly.
 [assembly: VendorInfo("My Company", "https://my-company.com")]
 
-namespace ExampleAdapter {
+namespace ExampleHostedAdapter {
 
     // This is your adapter class. For information about how to add features to your adapter (such 
     // as tag browsing, or real-time data queries), visit https://github.com/intelligentplant/AppStoreConnect.Adapters.
@@ -28,13 +29,13 @@ namespace ExampleAdapter {
         // The adapter type description.
         Description = "A brief description of the adapter type"
     )]
-    public class MyAdapter : AdapterBase<MyAdapterOptions> {
+    public partial class ExampleHostedAdapter : AdapterBase<ExampleHostedAdapterOptions> {
 
-        public MyAdapter(
+        public ExampleHostedAdapter(
             string id,
-            MyAdapterOptions options,
+            IOptionsMonitor<ExampleHostedAdapterOptions> options,
             IBackgroundTaskService taskScheduler,
-            ILogger<MyAdapter> logger
+            ILogger<ExampleHostedAdapter> logger
         ) : base(id, options, taskScheduler, logger) { }
 
 
@@ -52,6 +53,15 @@ namespace ExampleAdapter {
         // methods to dispose of resources when the adapter is being disposed.
         protected override Task StopAsync(CancellationToken cancellationToken) {
             return Task.CompletedTask;
+        }
+
+
+        // The OnOptionsChange method is called every time the adapter receives an update to its
+        // options at runtime. You can use this method to trigger any runtime changes required.
+        // You can test this functionality by running the application and then changing the
+        // adapter name or description in appsettings.json at runtime.
+        protected override void OnOptionsChange(ExampleHostedAdapterOptions options) {
+            base.OnOptionsChange(options);
         }
 
 

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/ExampleHostedAdapter.csproj
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/ExampleHostedAdapter.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter" Version="2.0.0" />
+    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter.AspNetCore.Grpc" Version="2.0.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.Jaeger" Version="1.0.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.0.0-rc3" />
+  </ItemGroup>
+  
+</Project>

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/ExampleHostedAdapterOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/ExampleHostedAdapterOptions.cs
@@ -1,0 +1,14 @@
+﻿using DataCore.Adapter;
+
+namespace ExampleHostedAdapter {
+
+    // This class defines the runtime options used to configure your adapter.
+
+    public class ExampleHostedAdapterOptions : AdapterOptions {
+
+        // Add properties required to configure your adapter e.g. connection endpoints, 
+        // credentials, etc. The Startup.cs file is configured to bind adapter options
+        // via the app configuration (e.g. appsettings.json).
+
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/Program.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/Program.cs
@@ -1,0 +1,17 @@
+﻿
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace ExampleHostedAdapter {
+    public class Program {
+        public static void Main(string[] args) {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder => {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/Properties/launchSettings.json
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "profiles": {
+    "ExampleAdapterHost": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:44300",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/README.md
@@ -1,0 +1,12 @@
+﻿# App Store Connect Adapter Host: ExampleHostedAdapter
+
+This App Store Connect adapter uses a [starter template](https://github.com/intelligentplant/IndustrialAppStore.ClientTools.DotNet) from the [Industrial App Store](https://appstore.intelligentplant.com). The adapter is hosted by an ASP.NET Core application. You can connect an App Store Connect instance to your adapter via HTTP or gRPC.
+
+
+# Getting Started
+
+The `ExampleHostedAdapter` and `ExampleHostedAdapterOptions` classes define the adapter and its runtime options respectively. You can change the names of these classes as you wish. The `ExampleHostedAdapter` class is split across three separate code files (`ExampleHostedAdapter.cs`, `ExampleHostedAdapter.TagSearch.cs`, and `ExampleHostedAdapter.ReadSnapshotTagValues.cs`) and implements tag search and real-time value polling features.
+
+For information about how to implement adapter features, as well as example projects, please visit the [App Store Connect adapters GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters).
+
+The `Startup` class configures the dependency injection container and application pipeline for the ASP.NET Core application. The `appsettings.json` file provides configuration settings for the application, including the `ExampleHostedAdapterOptions` instance that is passed to the `ExampleHostedAdapter` instance at runtime.

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/README.md
@@ -10,3 +10,11 @@ The `ExampleHostedAdapter` and `ExampleHostedAdapterOptions` classes define the 
 For information about how to implement adapter features, as well as example projects, please visit the [App Store Connect adapters GitHub repository](https://github.com/intelligentplant/AppStoreConnect.Adapters).
 
 The `Startup` class configures the dependency injection container and application pipeline for the ASP.NET Core application. The `appsettings.json` file provides configuration settings for the application, including the `ExampleHostedAdapterOptions` instance that is passed to the `ExampleHostedAdapter` instance at runtime.
+
+
+# Connecting App Store Connect to the Adapter
+
+To connect a local App Store Connect instance to your adapter, configure a new `App Store Connect Adapter (HTTP Proxy)` data source in the App Store Connect UI, using the following settings:
+
+- `Address`: https://localhost:44300/
+- `Adapter ID`: fdb421d7-03b2-49e8-880a-224e8e5f04ef

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/Startup.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/Startup.cs
@@ -1,0 +1,109 @@
+﻿using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace ExampleHostedAdapter {
+    public class Startup {
+
+        // Our adapter instance will use this ID at runtime.
+        public const string AdapterId = "fdb421d7-03b2-49e8-880a-224e8e5f04ef";
+
+
+        public IConfiguration Configuration { get; }
+
+
+        public Startup(IConfiguration configuration) {
+            Configuration = configuration;
+        }
+
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+        public void ConfigureServices(IServiceCollection services) {
+            // Add adapter services
+
+            var version = GetType().Assembly.GetName().Version.ToString(3);
+
+            services
+                .AddDataCoreAdapterAspNetCoreServices()
+                .AddHostInfo("ExampleHostedAdapter Host", "A host application for an App Store Connect adapter")
+                .AddServices(svc => {
+                    // Bind adapter options against the application configuration.
+                    svc.Configure<ExampleHostedAdapterOptions>(AdapterId, Configuration.GetSection($"AppStoreConnect:Settings:{AdapterId}"));
+                })
+                // Register our adapter with the DI container. The AdapterId parameter will be
+                // used as the adapter ID.
+                .AddAdapter(sp => ActivatorUtilities.CreateInstance<ExampleHostedAdapter>(sp, AdapterId));
+            //.AddAdapterFeatureAuthorization<MyAdapterFeatureAuthHandler>();
+
+            // To add authentication and authorization for adapter API operations, extend 
+            // the FeatureAuthorizationHandler class and call AddAdapterFeatureAuthorization
+            // above to register your handler.
+
+            services.AddGrpc();
+
+            services.AddMvc()
+                .SetCompatibilityVersion(CompatibilityVersion.Latest)
+                .AddJsonOptions(options => {
+                    options.JsonSerializerOptions.WriteIndented = true;
+                })
+                .AddDataCoreAdapterMvc();
+
+            // Add OpenTelemetry tracing
+            services.AddOpenTelemetryTracing(builder => {
+                builder
+                    .SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(
+                        "IAS Adapter Host",
+                        serviceVersion: version,
+                        serviceInstanceId: AdapterId
+                    ))
+                    // Use AddConsoleExporter() to export to stdout. 
+                    //.AddConsoleExporter()    
+                    // Use AddJaegerExporter() to export to Jaeger (https://www.jaegertracing.io/).
+                    //.AddJaegerExporter() 
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddSqlClientInstrumentation()
+                    .AddDataCoreAdapterInstrumentation();
+            });
+        }
+
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
+            if (env.IsDevelopment()) {
+                app.UseDeveloperExceptionPage();
+            }
+            else {
+                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRequestLocalization();
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints => {
+                // Map MVC API and gRPC endpoints.
+                endpoints.MapControllers();
+                endpoints.MapDataCoreGrpcServices();
+
+                // Redirect requests to / to the API endpoint for retrieving details about the
+                // adapter.
+                endpoints.MapGet("/", context => {
+                    context.Response.Redirect($"/api/app-store-connect/v2.0/adapters/{AdapterId}");
+                    return Task.CompletedTask;
+                });
+            });
+        }
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/appsettings.Development.json
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/appsettings.json
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/appsettings.json
@@ -1,0 +1,23 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http1AndHttp2"
+    }
+  },
+  "AppStoreConnect": {
+    "Settings": {
+      "fdb421d7-03b2-49e8-880a-224e8e5f04ef": {
+        "Name": "My Example Adapter",
+        "Description": "An example adapter generated using a template."
+      }
+    }
+  }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/appsettings.json
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iashostedadapter/appsettings.json
@@ -10,6 +10,11 @@
   "Kestrel": {
     "EndpointDefaults": {
       "Protocols": "Http1AndHttp2"
+    },
+    "Endpoints": {
+      "Https": {
+        "Url": "https://localhost:44300"
+      }
     }
   },
   "AppStoreConnect": {


### PR DESCRIPTION
Adds a template for `dotnet new` for creating an App Store Connect adapter that is hosted externally to App Store Connect using an ASP.NET Core host application.