### PR TITLE
Token store and cookie improvements

### DIFF
--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/ClaimsPrincipalExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/ClaimsPrincipalExtensions.cs
@@ -1,20 +1,69 @@
 ﻿using System.Security.Claims;
 
 namespace IntelligentPlant.IndustrialAppStore.Authentication {
+
+    /// <summary>
+    /// Extensions for <see cref="ClaimsPrincipal"/>.
+    /// </summary>
     public static class ClaimsPrincipalExtensions {
 
+        /// <summary>
+        /// Gets the organisation name for the <see cref="ClaimsPrincipal"/>.
+        /// </summary>
+        /// <param name="principal">
+        ///   The <see cref="ClaimsPrincipal"/>.
+        /// </param>
+        /// <returns>
+        ///   The value of the principal's <see cref="IndustrialAppStoreAuthenticationDefaults.OrgNameClaimType"/> 
+        ///   claim, or <see langword="null"/> if the claim was not found.
+        /// </returns>
         public static string GetOrganisationName(this ClaimsPrincipal principal) {
             return principal?.FindFirst(IndustrialAppStoreAuthenticationDefaults.OrgNameClaimType)?.Value;
         }
 
 
+        /// <summary>
+        /// Gets the organisation identifier for the <see cref="ClaimsPrincipal"/>.
+        /// </summary>
+        /// <param name="principal">
+        ///   The <see cref="ClaimsPrincipal"/>.
+        /// </param>
+        /// <returns>
+        ///   The value of the principal's <see cref="IndustrialAppStoreAuthenticationDefaults.OrgIdentifierClaimType"/> 
+        ///   claim, or <see langword="null"/> if the claim was not found.
+        /// </returns>
         public static string GetOrganisationId(this ClaimsPrincipal principal) {
             return principal?.FindFirst(IndustrialAppStoreAuthenticationDefaults.OrgIdentifierClaimType)?.Value;
         }
 
 
+        /// <summary>
+        /// Gets the profile picture IRL for the <see cref="ClaimsPrincipal"/>.
+        /// </summary>
+        /// <param name="principal">
+        ///   The <see cref="ClaimsPrincipal"/>.
+        /// </param>
+        /// <returns>
+        ///   The value of the principal's <see cref="IndustrialAppStoreAuthenticationDefaults.PictureClaimType"/> 
+        ///   claim, or <see langword="null"/> if the claim was not found.
+        /// </returns>
         public static string GetProfilePictureUrl(this ClaimsPrincipal principal) {
             return principal?.FindFirst(IndustrialAppStoreAuthenticationDefaults.PictureClaimType)?.Value;
+        }
+
+
+        /// <summary>
+        /// Gets the app session ID for the <see cref="ClaimsPrincipal"/>.
+        /// </summary>
+        /// <param name="principal">
+        ///   The <see cref="ClaimsPrincipal"/>.
+        /// </param>
+        /// <returns>
+        ///   The value of the principal's <see cref="IndustrialAppStoreAuthenticationDefaults.AppSessionIdClaimType"/> 
+        ///   claim, or <see langword="null"/> if the claim was not found.
+        /// </returns>
+        public static string GetSessionId(this ClaimsPrincipal principal) { 
+            return principal?.FindFirst(IndustrialAppStoreAuthenticationDefaults.AppSessionIdClaimType)?.Value;
         }
 
     }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/ITokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/ITokenStore.cs
@@ -24,14 +24,11 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <param name="sessionId">
         ///   The login session ID for the authenticated user.
         /// </param>
-        /// <param name="properties">
-        ///   The <see cref="AuthenticationProperties"/> for the authenticated user.
-        /// </param>
         /// <returns>
         ///   A <see cref="ValueTask"/> that will perform any required implementation-specific 
         ///   initialisation.
         /// </returns>
-        ValueTask InitAsync(string userId, string sessionId, AuthenticationProperties properties);
+        ValueTask InitAsync(string userId, string sessionId);
 
         /// <summary>
         /// Gets the tokens associated with the authenticated user.

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 using IntelligentPlant.IndustrialAppStore.Client;
 
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -101,9 +102,21 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         public Action<IHttpClientBuilder> ConfigureHttpClient { get; set; }
 
         /// <summary>
-        /// Additional event handlers for OAuth authentication events.
+        /// Additional event handlers for cookie authentication events raised by the application.
         /// </summary>
-        public OAuthEvents Events { get; set; }
+        /// <remarks>
+        ///   Ignored when <see cref="UseExternalAuthentication"/> is <see langword="true"/>.
+        /// </remarks>
+        public CookieAuthenticationEvents CookieAuthenticationEvents { get; set; }
+
+        /// <summary>
+        /// Additional event handlers for OAuth authentication events raised when signing a user 
+        /// into the application using the Industrial App Store.
+        /// </summary>
+        /// <remarks>
+        ///   Ignored when <see cref="UseExternalAuthentication"/> is <see langword="true"/>.
+        /// </remarks>
+        public OAuthEvents OAuthEvents { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStore.cs
@@ -47,12 +47,6 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// </summary>
         protected string SessionId { get; private set; }
 
-        /// <summary>
-        /// The <see cref="Microsoft.AspNetCore.Authentication.AuthenticationProperties"/> for the 
-        /// token store.
-        /// </summary>
-        protected AuthenticationProperties AuthenticationProperties { get; private set; }
-
 
         /// <summary>
         /// Creates a new <see cref="TokenStore"/> object.
@@ -78,15 +72,38 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
 
 
         /// <inheritdoc/>
-        async ValueTask ITokenStore.InitAsync(string userId, string sessionId, AuthenticationProperties properties) {
+        async ValueTask ITokenStore.InitAsync(string userId, string sessionId) {
+            await InitCoreAsync(userId, sessionId).ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Initialises the token store.
+        /// </summary>
+        /// <param name="userId">
+        ///   The user ID for the token store.
+        /// </param>
+        /// <param name="sessionId">
+        ///   The session ID for the token store.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will initialise the token store.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="userId"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="sessionId"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The token store has already been initialised.
+        /// </exception>
+        protected async ValueTask InitCoreAsync(string userId, string sessionId) {
             if (userId == null) {
                 throw new ArgumentNullException(nameof(userId));
             }
             if (sessionId == null) {
                 throw new ArgumentNullException(nameof(sessionId));
-            }
-            if (properties == null) {
-                throw new ArgumentNullException(nameof(properties));
             }
             if (Interlocked.CompareExchange(ref _initialised, 1, 0) != 0) {
                 throw new InvalidOperationException(Resources.Error_TokenStoreHasAlreadyBeenInitialised);
@@ -94,7 +111,6 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
 
             UserId = userId;
             SessionId = sessionId;
-            AuthenticationProperties = properties;
 
             await InitAsync();
         }


### PR DESCRIPTION
Simplify initialisation of custom token stores so that they do not require an `AuthenticationProperties` instance.
Add hooks into cookie authentication events in `IndustriapAppStoreAuthenticationOptions`.