### PR TITLE
Specify initial sample time when creating script tags

### DIFF
--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagSettings.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagSettings.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model.Scripting {
@@ -68,6 +69,16 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         [Required]
         [MaxLength(100)]
         public string ApplicationName { get; set; }
+
+        /// <summary>
+        /// The initial start time for the script tag calculation, used on the first evaluation of 
+        /// the script only.
+        /// </summary>
+        /// <remarks>
+        ///   If an initial start time is not specified, an appropriate start time will be 
+        ///   inferred when the script tag is first evaluated.
+        /// </remarks>
+        public DateTime? InitialSampleTime { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/TemplatedScriptTagSettings.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/TemplatedScriptTagSettings.cs
@@ -104,5 +104,15 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
         [MaxLength(100)]
         public string ApplicationName { get; set; }
 
+        /// <summary>
+        /// The initial start time for the script tag calculation, used on the first evaluation of 
+        /// the script only.
+        /// </summary>
+        /// <remarks>
+        ///   If an initial start time is not specified, an appropriate start time will be 
+        ///   inferred when the script tag is first evaluated.
+        /// </remarks>
+        public DateTime? InitialSampleTime { get; set; }
+
     }
 }


### PR DESCRIPTION
When creating a script tag (ad hoc or templated) the initial sample time to calculate the script tag at can now be specified