### PR TITLE
Backchannel client

### DIFF
--- a/samples/CustomTokenStoreExample/README.md
+++ b/samples/CustomTokenStoreExample/README.md
@@ -2,11 +2,13 @@
 
 This project demonstrates how to use a custom [ITokenStore](../../src/IntelligentPlant.IndustrialAppStore.Authentication/ITokenStore.cs) to store access and refresh tokens obtained by an [Industrial App Store](https://appstore.intelligentplant.com) app.
 
-The functionality of the app itself is identical to the example MVC application found [here](../ExampleMvcApplication).
+The functionality of the app itself is based on the example MVC application found [here](../ExampleMvcApplication).
 
-The [EFTokenStore](./EFTokenStore.cs) class uses an Entity Framework Core database context to load and save tokens. Note that the project is configured to use an in-memory SQLite database that will not persist any data between app restarts!
+The [EFTokenStore](./Services/EFTokenStore.cs) class uses an Entity Framework Core database context to load and save tokens. Note that the project is configured to use an in-memory SQLite database that will not persist any data between app restarts!
 
 Tokens are protected at rest using the `ProtectedData` class. This class is not available on non-Windows platforms; an alternative encryption solution would be required if a different platform was being targeted, or if a common database was being shared by multiple app instances.
+
+The project also demonstrates how the [BackchannelIndustrialAppStoreHttpClient](../../src/IntelligentPlant.IndustrialAppStore.Authentication/BackchannelIndustrialAppStoreHttpClient.cs) can be used to perform backchannel API calls to the Industrial App Store outside of the app's HTTP request pipeline. The [BackgroundGroupFetcher](./Services/BackgroundGroupFetcher.cs) class is an `IHostedService` implementation that is notified when a user signs into the app and downloads information about the user's Industrial App Store group memberships.
 
 
 # Bootstrapping

--- a/samples/CustomTokenStoreExample/Services/BackgroundGroupFetcher.cs
+++ b/samples/CustomTokenStoreExample/Services/BackgroundGroupFetcher.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+using IntelligentPlant.IndustrialAppStore.Authentication;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ExampleMvcApplication.Services {
+    public class BackgroundGroupFetcher : BackgroundService {
+
+        private static readonly Channel<UserLogonEvent> s_channel = Channel.CreateUnbounded<UserLogonEvent>(new UnboundedChannelOptions() { 
+            AllowSynchronousContinuations = false,
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+        private readonly IServiceProvider _serviceProvider;
+
+        private readonly ILogger _logger;
+
+
+        public BackgroundGroupFetcher(IServiceProvider serviceProvider, ILogger<BackgroundGroupFetcher> logger) { 
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        public static async ValueTask OnUserLogonAsync(UserLogonEvent userLogonEvent, CancellationToken cancellationToken) {
+            await s_channel.Writer.WriteAsync(userLogonEvent, cancellationToken);
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
+            await foreach (var logonEvent in s_channel.Reader.ReadAllAsync(stoppingToken)) {
+                using (var scope = _serviceProvider.CreateScope()) {
+                    var client = scope.ServiceProvider.GetRequiredService<BackchannelIndustrialAppStoreHttpClient>();
+                    var tokenStore = scope.ServiceProvider.GetRequiredService<ITokenStore>();
+                    await tokenStore.InitAsync(logonEvent.UserId, logonEvent.SessionId);
+
+                    var userInfo = await client.UserInfo.GetUserInfoAsync(tokenStore, stoppingToken);
+                    var groups = await client.Organization.GetGroupMembershipsAsync(tokenStore, stoppingToken);
+                    foreach (var group in groups) {
+                        _logger.LogInformation($"{userInfo.DisplayName} is a member of {group.DisplayName} (Organisation: {group.Org})");
+                    }
+                }
+            }
+        }
+    }
+
+
+    public record UserLogonEvent(string UserId, string SessionId);
+}

--- a/samples/CustomTokenStoreExample/Services/EFTokenStore.cs
+++ b/samples/CustomTokenStoreExample/Services/EFTokenStore.cs
@@ -8,7 +8,7 @@ using IntelligentPlant.IndustrialAppStore.Authentication;
 
 using Microsoft.AspNetCore.Authentication;
 
-namespace ExampleMvcApplication {
+namespace ExampleMvcApplication.Services {
 
     /// <summary>
     /// <see cref="ITokenStore"/> implementation that stores user tokens in an EF Core database 

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/ClaimsPrincipalExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/ClaimsPrincipalExtensions.cs
@@ -8,6 +8,36 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
     public static class ClaimsPrincipalExtensions {
 
         /// <summary>
+        /// Gets the user ID for the <see cref="ClaimsPrincipal"/>.
+        /// </summary>
+        /// <param name="principal">
+        ///   The <see cref="ClaimsPrincipal"/>.
+        /// </param>
+        /// <returns>
+        ///   The value of the principal's <see cref="ClaimTypes.NameIdentifier"/> 
+        ///   claim, or <see langword="null"/> if the claim was not found.
+        /// </returns>
+        public static string GetUserId(this ClaimsPrincipal principal) {
+            return principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        }
+
+
+        /// <summary>
+        /// Gets the user name for the <see cref="ClaimsPrincipal"/>.
+        /// </summary>
+        /// <param name="principal">
+        ///   The <see cref="ClaimsPrincipal"/>.
+        /// </param>
+        /// <returns>
+        ///   The value of the principal's <see cref="ClaimTypes.Name"/> 
+        ///   claim, or <see langword="null"/> if the claim was not found.
+        /// </returns>
+        public static string GetUserName(this ClaimsPrincipal principal) {
+            return principal?.FindFirst(ClaimTypes.Name)?.Value;
+        }
+
+
+        /// <summary>
         /// Gets the organisation name for the <see cref="ClaimsPrincipal"/>.
         /// </summary>
         /// <param name="principal">

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/ITokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/ITokenStore.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Authentication;
 
@@ -16,6 +17,11 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
     public interface ITokenStore {
 
         /// <summary>
+        /// Specifies if the <see cref="ITokenStore"/> has been initialised.
+        /// </summary>
+        bool Ready { get; }
+
+        /// <summary>
         /// Initialises the <see cref="ITokenStore"/> using the specified settings.
         /// </summary>
         /// <param name="userId">
@@ -28,6 +34,15 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ///   A <see cref="ValueTask"/> that will perform any required implementation-specific 
         ///   initialisation.
         /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="userId"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="sessionId"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The <see cref="ITokenStore"/> has already been initialised.
+        /// </exception>
         ValueTask InitAsync(string userId, string sessionId);
 
         /// <summary>
@@ -38,6 +53,9 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ///   authenticated user, or <see langword="null"/> if the access token is unavailable or 
         ///   has expired.
         /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   The <see cref="ITokenStore"/> has not been initialised.
+        /// </exception>
         ValueTask<OAuthTokens?> GetTokensAsync();
 
         /// <summary>
@@ -49,6 +67,9 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <returns>
         ///   A <see cref="ValueTask"/> that will save the tokens.
         /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   The <see cref="ITokenStore"/> has not been initialised.
+        /// </exception>
         ValueTask SaveTokensAsync(OAuthTokens tokens);
 
     }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStore.cs
@@ -37,6 +37,9 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// </summary>
         private int _initialised;
 
+        /// <inheritdoc/>
+        public bool Ready => _initialised == 1;
+
         /// <summary>
         /// The user ID for the token store.
         /// </summary>
@@ -118,7 +121,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
 
         /// <inheritdoc/>
         async ValueTask<OAuthTokens?> ITokenStore.GetTokensAsync() {
-            if (_initialised == 0) {
+            if (!Ready) {
                 throw new InvalidOperationException(Resources.Error_TokenStoreHasNotBeenInitialised);
             }
 
@@ -161,7 +164,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
 
         /// <inheritdoc/>
         async ValueTask ITokenStore.SaveTokensAsync(OAuthTokens tokens) {
-            if (_initialised == 0) {
+            if (!Ready) {
                 throw new InvalidOperationException(Resources.Error_TokenStoreHasNotBeenInitialised);
             }
             await SaveTokensAsync(tokens);


### PR DESCRIPTION
Adds a new `BackchannelIndustrialAppStoreHttpClient` type, intended to allow apps to perform IAS operations on behalf of an authenticated user outside of the app's HTTP request pipeline.

The `BackchannelIndustrialAppStoreHttpClient` is automatically registered with the app's `IServiceProvider` when registering Industrial App Store authentication, and accepts an `ITokenStore` parameter on every operation instead of an `HttpContext`. This allows an app to store access tokens and refresh tokens in a custom token store and run background operations on behalf of the user even when they are not actively using the app.