### PR TITLE
Nullable reference types and session ID generation

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -11,6 +11,7 @@
     <SignOutput>false</SignOutput>
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
     <IncludeDevelopmentPackages>false</IncludeDevelopmentPackages>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,5 +7,7 @@
 
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/src/IntelligentPlant.DataCore.HttpClient/AuthenticationCallback.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/AuthenticationCallback.cs
@@ -26,9 +26,9 @@ namespace IntelligentPlant.DataCore.Client {
     ///   <c>Authorize</c> header in the outgoing request. If the return value is 
     ///   <see langword="null"/>, no <c>Authorize</c> header will be set.
     /// </returns>
-    public delegate Task<AuthenticationHeaderValue> AuthenticationCallback<TContext>(
+    public delegate Task<AuthenticationHeaderValue?> AuthenticationCallback<TContext>(
         HttpRequestMessage request, 
-        TContext context, 
+        TContext? context, 
         CancellationToken cancellationToken
     );
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/AssetModelClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/AssetModelClient.cs
@@ -56,7 +56,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         ///   A task that will return the asset model data sources.
         /// </returns>
         public async Task<IEnumerable<DataSourceInfo>> GetAssetModelDataSources(
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             var url = GetAbsoluteUrl("api/assetmodel/datasources");
@@ -95,7 +95,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<AssetModelElementTemplate>> FindAssetModelElementTemplatesAsync(
             FindAssetModelElementTemplatesRequest request, 
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -139,7 +139,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<AssetModelElementTemplate>> GetAssetModelElementTemplateAsync(
             GetAssetModelElementTemplateRequest request, 
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -183,7 +183,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<AssetModelPropertyTemplate>> FindAssetModelPropertyTemplatesAsync(
             FindAssetModelPropertyTemplatesRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -227,7 +227,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<AssetModelElement>> FindAssetModelElementsAsync(
             FindAssetModelElementsRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -275,7 +275,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<AssetModelElement> GetAssetModelElementAsync(
             GetAssetModelElementRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/ClientBase.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/ClientBase.cs
@@ -63,7 +63,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="relativeUrl"/> is <see langword="null"/>.
         /// </exception>
-        protected Uri GetAbsoluteUrl(string relativeUrl) {
+        protected Uri? GetAbsoluteUrl(string relativeUrl) {
             return GetAbsoluteUrl(BaseUrl, relativeUrl);
         }
 
@@ -106,7 +106,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="relativeUrl"/> is <see langword="null"/>.
         /// </exception>
-        internal static Uri GetAbsoluteUrl(Uri baseUrl, string relativeUrl) {
+        internal static Uri? GetAbsoluteUrl(Uri baseUrl, string relativeUrl) {
             if (baseUrl == null) {
                 throw new ArgumentNullException(nameof(baseUrl));
             }

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/CustomFunctionsClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/CustomFunctionsClient.cs
@@ -70,7 +70,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
             HttpClient httpClient, 
             Uri url,
             CustomFunctionRequest request,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/DataSourcesClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/DataSourcesClient.cs
@@ -65,7 +65,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         ///   A task that will return information about the running data sources.
         /// </returns>
         public async Task<IEnumerable<DataSourceInfo>> GetDataSourcesAsync(
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             var url = GetAbsoluteUrl("api/data/datasources");
@@ -104,7 +104,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<DataSourceInfo> GetDataSourceAsync(
             string dataSourceName,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (string.IsNullOrWhiteSpace(dataSourceName)) {
@@ -147,7 +147,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ComponentRoles> IsAuthorizedAsync(
             IsAuthorizedOnDataSourceRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -201,7 +201,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<TagSearchResult>> FindTagsAsync(
             FindTagsRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -250,7 +250,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IDictionary<string, SnapshotTagValueDictionary>> ReadSnapshotTagValuesAsync(
             ReadSnapshotTagValuesRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -299,7 +299,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IDictionary<string, HistoricalTagValuesDictionary>> ReadRawTagValuesAsync(
             ReadRawTagValuesRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -346,7 +346,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IDictionary<string, HistoricalTagValuesDictionary>> ReadPlotTagValuesAsync(
             ReadPlotTagValuesRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -392,7 +392,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IDictionary<string, HistoricalTagValuesDictionary>> ReadProcessedTagValuesAsync(
             ReadProcessedTagValuesRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -438,7 +438,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IDictionary<string, HistoricalTagValuesDictionary>> ReadTagValuesAtTimesAsync(
             ReadTagValuesAtTimesRequest request, 
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -488,7 +488,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<TagValueUpdateResponse>> WriteSnapshotTagValuesAsync(
             WriteTagValuesRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -537,7 +537,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<TagValueUpdateResponse>> WriteHistoricalTagValuesAsync(
             WriteTagValuesRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -586,7 +586,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<AnnotationCollection>> ReadAnnotationsAsync(
             ReadAnnotationsRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -634,7 +634,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<Annotation> CreateAnnotationAsync(
             CreateAnnotationRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -679,7 +679,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task UpdateAnnotationAsync(
             UpdateAnnotationRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -724,7 +724,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task DeleteAnnotationAsync(
             DeleteAnnotationRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -770,7 +770,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<ScriptEngine>> GetScriptEnginesAsync(
             GetDataSourceScriptEnginesRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -814,7 +814,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<ScriptTemplate>> FindScriptTagTemplatesAsync(
             FindScriptTagTemplatesRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -858,7 +858,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ScriptTemplateWithParameterDefinitions> GetScriptTagTemplateAsync(
             GetScriptTagTemplateRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -902,7 +902,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<ScriptTagDefinition>> FindScriptTagsAsync(
             FindTagsRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -948,7 +948,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<IEnumerable<ScriptTagDefinition>> GetScriptTagsAsync(
             GetTagsRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -994,7 +994,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ScriptTagDefinition> GetScriptTagAsync(
             GetTagRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -1038,7 +1038,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ScriptTagDefinition> CreateScriptTagAsync(
             CreateScriptTagRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -1084,7 +1084,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ScriptTagDefinition> CreateScriptTagFromTemplateAsync(
             CreateTemplatedScriptTagRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -1130,7 +1130,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ScriptTagDefinition> UpdateScriptTagAsync(
             UpdateScriptTagRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -1176,7 +1176,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ScriptTagDefinition> UpdateScriptTagFromTemplateAsync(
             UpdateTemplatedScriptTagRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -1222,7 +1222,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<bool> DeleteScriptTagAsync(
             DeleteScriptTagRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -1279,8 +1279,8 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         public async Task<T> RunCustomFunctionAsync<T>(
             string dataSourceName, 
             string functionName, 
-            IDictionary<string, string> parameters = null,
-            TContext context = default, 
+            IDictionary<string, string>? parameters = null,
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (string.IsNullOrWhiteSpace(dataSourceName)) {
@@ -1296,7 +1296,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
 
             return await CustomFunctionsClient<TContext, TOptions>.RunCustomFunctionAsync<T>(
                 HttpClient,
-                GetAbsoluteUrl("api/rpc"),
+                GetAbsoluteUrl("api/rpc")!,
                 request, 
                 context, 
                 cancellationToken

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/EventSinksClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/EventSinksClient.cs
@@ -62,7 +62,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         ///   A task that will return information about the running event sinks.
         /// </returns>
         public async Task<IEnumerable<ComponentInfo>> GetEventSinksAsync(
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             var url = GetAbsoluteUrl("api/data/eventsinks");
@@ -101,7 +101,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ComponentInfo> GetEventSinkAsync(
             string eventSinkName,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (string.IsNullOrWhiteSpace(eventSinkName)) {
@@ -144,7 +144,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ComponentRoles> IsAuthorizedAsync(
             IsAuthorizedOnEventSinkRequest request,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -208,8 +208,8 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         public async Task<T> RunCustomFunctionAsync<T>(
             string eventSinkName, 
             string functionName, 
-            IDictionary<string, string> parameters = null,
-            TContext context = default, 
+            IDictionary<string, string>? parameters = null,
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (string.IsNullOrWhiteSpace(eventSinkName)) {
@@ -225,7 +225,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
 
             return await CustomFunctionsClient<TContext, TOptions>.RunCustomFunctionAsync<T>(
                 HttpClient,
-                GetAbsoluteUrl("api/rpc"),
+                GetAbsoluteUrl("api/rpc")!,
                 request,
                 context,
                 cancellationToken

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/EventSourcesClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/EventSourcesClient.cs
@@ -62,7 +62,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         ///   A task that will return information about the running event sources.
         /// </returns>
         public async Task<IEnumerable<ComponentInfo>> GetEventSourcesAsync(
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             var url = GetAbsoluteUrl("api/data/eventsources");
@@ -101,7 +101,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ComponentInfo> GetEventSourceAsync(
             string eventSourceName, 
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (string.IsNullOrWhiteSpace(eventSourceName)) {
@@ -144,7 +144,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         /// </returns>
         public async Task<ComponentRoles> IsAuthorizedAsync(
             IsAuthorizedOnEventSourceRequest request, 
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -208,8 +208,8 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         public async Task<T> RunCustomFunctionAsync<T>(
             string eventSourceName, 
             string functionName, 
-            IDictionary<string, string> parameters = null, 
-            TContext context = default, 
+            IDictionary<string, string>? parameters = null, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             if (string.IsNullOrWhiteSpace(eventSourceName)) {
@@ -225,7 +225,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
 
             return await CustomFunctionsClient<TContext, TOptions>.RunCustomFunctionAsync<T>(
                 HttpClient,
-                GetAbsoluteUrl("api/rpc"),
+                GetAbsoluteUrl("api/rpc")!,
                 request,
                 context,
                 cancellationToken

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/InfoClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/InfoClient.cs
@@ -51,7 +51,7 @@ namespace IntelligentPlant.DataCore.Client.Clients {
         ///   The version of Data Core running at the remote endpoint.
         /// </returns>
         public async Task<string> GetDataCoreVersionAsync(
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) {
             var url = GetAbsoluteUrl("api/info");

--- a/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientException.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientException.cs
@@ -42,7 +42,7 @@ namespace IntelligentPlant.DataCore.Client {
         /// <summary>
         /// Gets the response content that was returned.
         /// </summary>
-        public string Content { get; }
+        public string? Content { get; }
 
         /// <summary>
         /// If a <c>Retry-After</c> header was included in the response, this property specifies 
@@ -55,7 +55,7 @@ namespace IntelligentPlant.DataCore.Client {
         /// be <see langword="null"/> unless the content type of the response was 
         /// <see cref="ProblemDetails.Constants.MediaType"/>.
         /// </summary>
-        public ProblemDetails.ProblemDetails ProblemDetails { get; }
+        public ProblemDetails.ProblemDetails? ProblemDetails { get; }
 
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace IntelligentPlant.DataCore.Client {
         /// <param name="inner">
         ///   The inner exception.
         /// </param>
-        public DataCoreHttpClientException(string message, string verb, string url, HttpStatusCode statusCode, IDictionary<string, string[]> requestHeaders, IDictionary<string, string[]> responseHeaders, string responseContent, ProblemDetails.ProblemDetails problemDetails, DateTime? utcRetryAfter, Exception inner) 
+        public DataCoreHttpClientException(string message, string verb, string url, HttpStatusCode statusCode, IDictionary<string, string[]> requestHeaders, IDictionary<string, string[]> responseHeaders, string? responseContent, ProblemDetails.ProblemDetails? problemDetails, DateTime? utcRetryAfter, Exception? inner) 
             : base(message, inner) {
             Verb = verb;
             Url = url;
@@ -180,7 +180,7 @@ namespace IntelligentPlant.DataCore.Client {
         ///   If the response contains an RFC 7807 problem details object, the <see cref="ProblemDetails"/> 
         ///   property of the exception will be set.
         /// </remarks>
-        internal static async Task<DataCoreHttpClientException> FromHttpResponseMessage(string errorMessage, HttpResponseMessage response, Exception inner) {
+        internal static async Task<DataCoreHttpClientException> FromHttpResponseMessage(string errorMessage, HttpResponseMessage response, Exception? inner) {
             if (response == null) {
                 throw new ArgumentNullException(nameof(response));
             }
@@ -198,7 +198,7 @@ namespace IntelligentPlant.DataCore.Client {
                 : false;
 
             var content = includeContent
-                ? await response.Content.ReadAsStringAsync().ConfigureAwait(false)
+                ? await response.Content!.ReadAsStringAsync().ConfigureAwait(false)
                 : null;
 
             var problemDetails = includeContent && contentTypes.Any(IsProblemDetailsResponse)

--- a/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientExtensions.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientExtensions.cs
@@ -39,7 +39,7 @@ namespace IntelligentPlant.DataCore.Client {
         /// <param name="utcTime">
         ///   The parsed UTC <see cref="DateTime"/>.
         /// </param>
-        private static void ParseTimeStamp(string absoluteOrRelativeTime, CultureInfo cultureInfo, TimeZoneInfo timeZone, string parameterName, out DateTime utcTime) {
+        private static void ParseTimeStamp(string absoluteOrRelativeTime, CultureInfo? cultureInfo, TimeZoneInfo? timeZone, string parameterName, out DateTime utcTime) {
             if (!IntelligentPlant.Relativity.RelativityParser.TryGetParser(cultureInfo, out var parser)) {
                 parser = IntelligentPlant.Relativity.RelativityParser.Default;
             }
@@ -63,7 +63,7 @@ namespace IntelligentPlant.DataCore.Client {
         /// <param name="ts">
         ///   The parsed <see cref="TimeSpan"/>.
         /// </param>
-        private static void ParseSampleInterval(string sampleInterval, CultureInfo cultureInfo, out TimeSpan ts) {
+        private static void ParseSampleInterval(string sampleInterval, CultureInfo? cultureInfo, out TimeSpan ts) {
             if (!IntelligentPlant.Relativity.RelativityParser.TryGetParser(cultureInfo, out var parser)) {
                 parser = IntelligentPlant.Relativity.RelativityParser.Default;
             }
@@ -123,12 +123,12 @@ namespace IntelligentPlant.DataCore.Client {
         public static Task<IEnumerable<TagSearchResult>> FindTagsAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client, 
             string dataSourceName, 
-            string nameFilter = "*", 
-            string descriptionFilter = null, 
-            string unitsFilter = null,
+            string? nameFilter = "*", 
+            string? descriptionFilter = null, 
+            string? unitsFilter = null,
             int page = 1,
             int pageSize = 20,
-            TContext context = default, 
+            TContext? context = default, 
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -196,12 +196,12 @@ namespace IntelligentPlant.DataCore.Client {
         public static Task<IEnumerable<ScriptTagDefinition>> FindScriptTagsAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
-            string nameFilter = "*",
-            string descriptionFilter = null,
-            string unitsFilter = null,
+            string? nameFilter = "*",
+            string? descriptionFilter = null,
+            string? unitsFilter = null,
             int page = 1,
             int pageSize = 20,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -258,10 +258,9 @@ namespace IntelligentPlant.DataCore.Client {
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> namesOrIds,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
-
             if (client == null) {
                 throw new ArgumentNullException(nameof(client));
             }
@@ -269,7 +268,7 @@ namespace IntelligentPlant.DataCore.Client {
             return client.GetScriptTagsAsync(
                 new GetTagsRequest() { 
                     DataSourceName = dataSourceName,
-                    TagNamesOrIds = namesOrIds?.ToArray()
+                    TagNamesOrIds = namesOrIds?.ToArray()!
                 },
                 context,
                 cancellationToken
@@ -312,7 +311,7 @@ namespace IntelligentPlant.DataCore.Client {
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             string nameOrId,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -368,8 +367,8 @@ namespace IntelligentPlant.DataCore.Client {
         public static Task<IDictionary<string, SnapshotTagValueDictionary>> ReadSnapshotTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             IDictionary<string, string[]> tagMap,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -379,7 +378,7 @@ namespace IntelligentPlant.DataCore.Client {
             return client.ReadSnapshotTagValuesAsync(
                 new ReadSnapshotTagValuesRequest() {
                     Tags = tagMap,
-                    QueryProperties = properties
+                    QueryProperties = properties!
                 },
                 context,
                 cancellationToken
@@ -421,12 +420,12 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The snapshot tag values, indexed by tag name.
         /// </returns>
-        public static async Task<SnapshotTagValueDictionary> ReadSnapshotTagValuesAsync<TContext, TOptions>(
+        public static async Task<SnapshotTagValueDictionary?> ReadSnapshotTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -440,7 +439,7 @@ namespace IntelligentPlant.DataCore.Client {
             var result = await client.ReadSnapshotTagValuesAsync(
                 new ReadSnapshotTagValuesRequest() {
                     Tags = new Dictionary<string, string[]>() {
-                        { dataSourceName, tagNames?.Distinct()?.ToArray() }
+                        { dataSourceName, tagNames?.Distinct()?.ToArray()! }
                     },
                     QueryProperties = properties
                 },
@@ -502,8 +501,8 @@ namespace IntelligentPlant.DataCore.Client {
             DateTime utcStartTime,
             DateTime utcEndTime,
             int pointCount,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -579,10 +578,10 @@ namespace IntelligentPlant.DataCore.Client {
             string absoluteOrRelativeStartTime,
             string absoluteOrRelativeEndTime,
             int pointCount,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -646,15 +645,15 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The historical tag values, indexed by data source name and then tag name.
         /// </returns>
-        public static async Task<HistoricalTagValuesDictionary> ReadRawTagValuesAsync<TContext, TOptions>(
+        public static async Task<HistoricalTagValuesDictionary?> ReadRawTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
             DateTime utcStartTime,
             DateTime utcEndTime,
             int pointCount,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -665,7 +664,7 @@ namespace IntelligentPlant.DataCore.Client {
             var result = await ReadRawTagValuesAsync(
                 client,
                 new Dictionary<string, string[]>() {
-                        { dataSourceName, tagNames?.Distinct()?.ToArray() }
+                        { dataSourceName, tagNames?.Distinct()?.ToArray()! }
                     },
                 utcStartTime,
                 utcEndTime,
@@ -730,17 +729,17 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The historical tag values, indexed by data source name and then tag name.
         /// </returns>
-        public static Task<HistoricalTagValuesDictionary> ReadRawTagValuesAsync<TContext, TOptions>(
+        public static Task<HistoricalTagValuesDictionary?> ReadRawTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
             string absoluteOrRelativeStartTime,
             string absoluteOrRelativeEndTime,
             int pointCount,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -816,8 +815,8 @@ namespace IntelligentPlant.DataCore.Client {
             DateTime utcStartTime,
             DateTime utcEndTime,
             int intervals,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -898,10 +897,10 @@ namespace IntelligentPlant.DataCore.Client {
             string absoluteOrRelativeStartTime,
             string absoluteOrRelativeEndTime,
             int intervals,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -970,15 +969,15 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The historical tag values, indexed by data source name and then tag name.
         /// </returns>
-        public static async Task<HistoricalTagValuesDictionary> ReadPlotTagValuesAsync<TContext, TOptions>(
+        public static async Task<HistoricalTagValuesDictionary?> ReadPlotTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
             DateTime utcStartTime,
             DateTime utcEndTime,
             int intervals,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -989,7 +988,7 @@ namespace IntelligentPlant.DataCore.Client {
             var result = await ReadPlotTagValuesAsync(
                 client,
                 new Dictionary<string, string[]>() {
-                        { dataSourceName, tagNames?.Distinct()?.ToArray() }
+                        { dataSourceName, tagNames?.Distinct()?.ToArray()! }
                     },
                 utcStartTime,
                 utcEndTime,
@@ -1059,17 +1058,17 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The historical tag values, indexed by data source name and then tag name.
         /// </returns>
-        public static Task<HistoricalTagValuesDictionary> ReadPlotTagValuesAsync<TContext, TOptions>(
+        public static Task<HistoricalTagValuesDictionary?> ReadPlotTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
             string absoluteOrRelativeStartTime,
             string absoluteOrRelativeEndTime,
             int intervals,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1145,8 +1144,8 @@ namespace IntelligentPlant.DataCore.Client {
             DateTime utcEndTime,
             string dataFunction,
             TimeSpan sampleInterval,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1223,9 +1222,9 @@ namespace IntelligentPlant.DataCore.Client {
             DateTime utcEndTime,
             string dataFunction,
             string sampleInterval,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1304,10 +1303,10 @@ namespace IntelligentPlant.DataCore.Client {
             string absoluteOrRelativeEndTime,
             string dataFunction,
             TimeSpan sampleInterval,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1386,10 +1385,10 @@ namespace IntelligentPlant.DataCore.Client {
             string absoluteOrRelativeEndTime,
             string dataFunction,
             string sampleInterval,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1459,7 +1458,7 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The historical tag values, indexed by data source name and then tag name.
         /// </returns>
-        public static async Task<HistoricalTagValuesDictionary> ReadProcessedTagValuesAsync<TContext, TOptions>(
+        public static async Task<HistoricalTagValuesDictionary?> ReadProcessedTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
@@ -1467,8 +1466,8 @@ namespace IntelligentPlant.DataCore.Client {
             DateTime utcEndTime,
             string dataFunction,
             TimeSpan sampleInterval,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1479,7 +1478,7 @@ namespace IntelligentPlant.DataCore.Client {
             var result = await ReadProcessedTagValuesAsync(
                 client,
                 new Dictionary<string, string[]>() {
-                    { dataSourceName, tagNames?.Distinct()?.ToArray() }
+                    { dataSourceName, tagNames?.Distinct()?.ToArray()! }
                 },
                 utcStartTime,
                 utcEndTime,
@@ -1544,7 +1543,7 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The historical tag values, indexed by data source name and then tag name.
         /// </returns>
-        public static Task<HistoricalTagValuesDictionary> ReadProcessedTagValuesAsync<TContext, TOptions>(
+        public static Task<HistoricalTagValuesDictionary?> ReadProcessedTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
@@ -1552,9 +1551,9 @@ namespace IntelligentPlant.DataCore.Client {
             DateTime utcEndTime,
             string dataFunction,
             string sampleInterval,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1630,7 +1629,7 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The historical tag values, indexed by data source name and then tag name.
         /// </returns>
-        public static Task<HistoricalTagValuesDictionary> ReadProcessedTagValuesAsync<TContext, TOptions>(
+        public static Task<HistoricalTagValuesDictionary?> ReadProcessedTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
@@ -1638,10 +1637,10 @@ namespace IntelligentPlant.DataCore.Client {
             string absoluteOrRelativeEndTime,
             string dataFunction,
             TimeSpan sampleInterval,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1718,7 +1717,7 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The historical tag values, indexed by data source name and then tag name.
         /// </returns>
-        public static Task<HistoricalTagValuesDictionary> ReadProcessedTagValuesAsync<TContext, TOptions>(
+        public static Task<HistoricalTagValuesDictionary?> ReadProcessedTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
@@ -1726,10 +1725,10 @@ namespace IntelligentPlant.DataCore.Client {
             string absoluteOrRelativeEndTime,
             string dataFunction,
             string sampleInterval,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1793,8 +1792,8 @@ namespace IntelligentPlant.DataCore.Client {
             this DataSourcesClient<TContext, TOptions> client, 
             IDictionary<string, string[]> tagMap, 
             IEnumerable<DateTime> utcSampleTimes, 
-            IDictionary<string, string> properties = null,
-            TContext context = default,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1805,7 +1804,7 @@ namespace IntelligentPlant.DataCore.Client {
             return client.ReadTagValuesAtTimesAsync(
                 new ReadTagValuesAtTimesRequest() {
                     Tags = tagMap,
-                    UtcSampleTimes = utcSampleTimes?.Distinct()?.ToArray(),
+                    UtcSampleTimes = utcSampleTimes?.Distinct()?.ToArray()!,
                     QueryProperties = properties
                 },
                 context,
@@ -1859,10 +1858,10 @@ namespace IntelligentPlant.DataCore.Client {
             this DataSourcesClient<TContext, TOptions> client,
             IDictionary<string, string[]> tagMap,
             IEnumerable<string> absoluteOrRelativeSampleTimes,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1927,13 +1926,13 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The historical tag values, indexed by data source name and then tag name.
         /// </returns>
-        public static async Task<HistoricalTagValuesDictionary> ReadTagValuesAtTimesAsync<TContext, TOptions>(
+        public static async Task<HistoricalTagValuesDictionary?> ReadTagValuesAtTimesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
             IEnumerable<DateTime> utcSampleTimes,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -1944,7 +1943,7 @@ namespace IntelligentPlant.DataCore.Client {
             var result = await ReadTagValuesAtTimesAsync(
                 client,
                 new Dictionary<string, string[]>() {
-                    { dataSourceName, tagNames?.Distinct()?.ToArray() }
+                    { dataSourceName, tagNames?.Distinct()?.ToArray()! }
                 },
                 utcSampleTimes,
                 properties,
@@ -2000,15 +1999,15 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   The historical tag values, indexed by data source name and then tag name.
         /// </returns>
-        public static async Task<HistoricalTagValuesDictionary> ReadTagValuesAtTimesAsync<TContext, TOptions>(
+        public static async Task<HistoricalTagValuesDictionary?> ReadTagValuesAtTimesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<string> tagNames,
             IEnumerable<string> absoluteOrRelativeSampleTimes,
-            IDictionary<string, string> properties = null,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            IDictionary<string, string>? properties = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
 
@@ -2027,7 +2026,7 @@ namespace IntelligentPlant.DataCore.Client {
             var result = await ReadTagValuesAtTimesAsync(
                 client,
                 new Dictionary<string, string[]>() {
-                    { dataSourceName, tagNames?.Distinct()?.ToArray() }
+                    { dataSourceName, tagNames?.Distinct()?.ToArray()! }
                 },
                 sampleTimes.Distinct().ToArray(),
                 properties,
@@ -2078,7 +2077,7 @@ namespace IntelligentPlant.DataCore.Client {
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<TagValue> values,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -2091,7 +2090,7 @@ namespace IntelligentPlant.DataCore.Client {
 
             return client.WriteSnapshotTagValuesAsync(new WriteTagValuesRequest() { 
                 DataSourceName = dataSourceName,
-                Values = values?.Where(x => x != null).ToArray()
+                Values = values?.Where(x => x != null).ToArray()!
             }, context, cancellationToken);
         }
 
@@ -2133,13 +2132,13 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   A <see cref="TagValueUpdateResponse"/> describing the write results for the tag.
         /// </returns>
-        public static async Task<TagValueUpdateResponse> WriteSnapshotTagValuesAsync<TContext, TOptions>(
+        public static async Task<TagValueUpdateResponse?> WriteSnapshotTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             string tagName,
             IDictionary<DateTime, double> values,
             TagValueStatus status = TagValueStatus.Good,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -2157,7 +2156,7 @@ namespace IntelligentPlant.DataCore.Client {
             var result = await WriteSnapshotTagValuesAsync(
                 client,
                 dataSourceName,
-                values?.OrderBy(x => x.Key).Select(x => new TagValue(tagName, x.Key, x.Value, null, status, null)),
+                values?.OrderBy(x => x.Key).Select(x => new TagValue(tagName, x.Key, x.Value, null, status, null))!,
                 context,
                 cancellationToken
             ).ConfigureAwait(false);
@@ -2203,13 +2202,13 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   A <see cref="TagValueUpdateResponse"/> describing the write results for the tag.
         /// </returns>
-        public static async Task<TagValueUpdateResponse> WriteSnapshotTagValuesAsync<TContext, TOptions>(
+        public static async Task<TagValueUpdateResponse?> WriteSnapshotTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             string tagName,
             IDictionary<DateTime, string> values,
             TagValueStatus status = TagValueStatus.Good,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -2227,7 +2226,7 @@ namespace IntelligentPlant.DataCore.Client {
             var result = await WriteSnapshotTagValuesAsync(
                 client,
                 dataSourceName,
-                values?.OrderBy(x => x.Key).Select(x => new TagValue(tagName, x.Key, double.NaN, x.Value, status, null)),
+                values?.OrderBy(x => x.Key).Select(x => new TagValue(tagName, x.Key, double.NaN, x.Value, status, null))!,
                 context,
                 cancellationToken
             ).ConfigureAwait(false);
@@ -2276,14 +2275,14 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   A <see cref="TagValueUpdateResponse"/> describing the write results for the tag.
         /// </returns>
-        public static async Task<TagValueUpdateResponse> WriteSnapshotTagValueAsync<TContext, TOptions>(
+        public static async Task<TagValueUpdateResponse?> WriteSnapshotTagValueAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             string tagName,
             DateTime utcSampleTime,
             double value,
             TagValueStatus status = TagValueStatus.Good,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -2359,14 +2358,14 @@ namespace IntelligentPlant.DataCore.Client {
         /// <returns>
         ///   A <see cref="TagValueUpdateResponse"/> describing the write results for the tag.
         /// </returns>
-        public static async Task<TagValueUpdateResponse> WriteSnapshotTagValueAsync<TContext, TOptions>(
+        public static async Task<TagValueUpdateResponse?> WriteSnapshotTagValueAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             string tagName,
             DateTime utcSampleTime,
             string value,
             TagValueStatus status = TagValueStatus.Good,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -2438,7 +2437,7 @@ namespace IntelligentPlant.DataCore.Client {
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             IEnumerable<TagValue> values,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -2451,7 +2450,7 @@ namespace IntelligentPlant.DataCore.Client {
 
             return client.WriteHistoricalTagValuesAsync(new WriteTagValuesRequest() {
                 DataSourceName = dataSourceName,
-                Values = values?.Where(x => x != null).ToArray()
+                Values = values?.Where(x => x != null).ToArray()!
             }, context, cancellationToken);
         }
 
@@ -2494,13 +2493,13 @@ namespace IntelligentPlant.DataCore.Client {
         ///   A <see cref="TagValueUpdateResponse"/> describing the write results for each tag 
         ///   that was written to.
         /// </returns>
-        public static async Task<TagValueUpdateResponse> WriteHistoricalTagValuesAsync<TContext, TOptions>(
+        public static async Task<TagValueUpdateResponse?> WriteHistoricalTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             string tagName,
             IDictionary<DateTime, double> values,
             TagValueStatus status = TagValueStatus.Good,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -2518,7 +2517,7 @@ namespace IntelligentPlant.DataCore.Client {
             var result = await WriteHistoricalTagValuesAsync(
                 client,
                 dataSourceName,
-                values?.OrderBy(x => x.Key).Select(x => new TagValue(tagName, x.Key, x.Value, null, status, null)),
+                values?.OrderBy(x => x.Key).Select(x => new TagValue(tagName, x.Key, x.Value, null, status, null))!,
                 context,
                 cancellationToken
             ).ConfigureAwait(false);
@@ -2565,13 +2564,13 @@ namespace IntelligentPlant.DataCore.Client {
         ///   A <see cref="TagValueUpdateResponse"/> describing the write results for each tag 
         ///   that was written to.
         /// </returns>
-        public static async Task<TagValueUpdateResponse> WriteHistoricalTagValuesAsync<TContext, TOptions>(
+        public static async Task<TagValueUpdateResponse?> WriteHistoricalTagValuesAsync<TContext, TOptions>(
             this DataSourcesClient<TContext, TOptions> client,
             string dataSourceName,
             string tagName,
             IDictionary<DateTime, string> values,
             TagValueStatus status = TagValueStatus.Good,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -2589,7 +2588,7 @@ namespace IntelligentPlant.DataCore.Client {
             var result = await WriteHistoricalTagValuesAsync(
                 client,
                 dataSourceName,
-                values?.OrderBy(x => x.Key).Select(x => new TagValue(tagName, x.Key, double.NaN, x.Value, status, null)),
+                values?.OrderBy(x => x.Key).Select(x => new TagValue(tagName, x.Key, double.NaN, x.Value, status, null))!,
                 context,
                 cancellationToken
             ).ConfigureAwait(false);
@@ -2645,7 +2644,7 @@ namespace IntelligentPlant.DataCore.Client {
             IEnumerable<string> tagNames,
             DateTime utcStartTime,
             DateTime utcEndTime,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {
@@ -2658,7 +2657,7 @@ namespace IntelligentPlant.DataCore.Client {
 
             var result = await client.ReadAnnotationsAsync(new ReadAnnotationsRequest() { 
                 DataSourceName = dataSourceName,
-                TagNames = tagNames?.ToArray(),
+                TagNames = tagNames?.ToArray()!,
                 StartTime = utcStartTime,
                 EndTime = utcEndTime
             }, context, cancellationToken).ConfigureAwait(false);
@@ -2718,9 +2717,9 @@ namespace IntelligentPlant.DataCore.Client {
             IEnumerable<string> tagNames,
             string absoluteOrRelativeStartTime,
             string absoluteOrRelativeEndTime,
-            TContext context = default,
-            CultureInfo cultureInfo = null,
-            TimeZoneInfo timeZone = null,
+            TContext? context = default,
+            CultureInfo? cultureInfo = null,
+            TimeZoneInfo? timeZone = null,
             CancellationToken cancellationToken = default
         ) where TOptions : DataCoreHttpClientOptions {
             if (client == null) {

--- a/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientOptions.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientOptions.cs
@@ -10,7 +10,7 @@ namespace IntelligentPlant.DataCore.Client {
         /// <summary>
         /// The base URL for Data Core API calls.
         /// </summary>
-        public Uri DataCoreUrl { get; set; }
+        public Uri DataCoreUrl { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Annotation.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Annotation.cs
@@ -16,7 +16,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// Gets or sets the application name for the annotation.
         /// </summary>
         [MaxLength(MaximumApplicationNameLength)]
-        public string ApplicationName { get; set; }
+        public string? ApplicationName { get; set; }
 
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the name of the user who created the annotation.
         /// </summary>
-        public string Creator { get; set; }
+        public string? Creator { get; set; }
 
         /// <summary>
         /// Gets or sets the UTC last modified time for the annotation.
@@ -45,7 +45,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// Analysis) to provide links where e.g. the workflow associated with the annotation can be 
         /// inspected.
         /// </summary>
-        public Uri MoreInfo { get; set; }
+        public Uri? MoreInfo { get; set; }
 
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <returns>
         /// <see langword="true"/> if the two instances are equivalent, otherwise <see langword="false"/>.
         /// </returns>
-        public bool Equals(Annotation other) {
+        public bool Equals(Annotation? other) {
             if (other == null) {
                 return false;
             }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AnnotationCollection.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AnnotationCollection.cs
@@ -9,12 +9,12 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the tag name.
         /// </summary>
-        public string TagName { get; set; }
+        public string TagName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the annotations.
         /// </summary>
-        public IEnumerable<Annotation> Annotations { get; set; }
+        public IEnumerable<Annotation> Annotations { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AnnotationIdentifier.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AnnotationIdentifier.cs
@@ -10,13 +10,13 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets a qualifying identifier for the annotation, to distinguish it from other annotations with the same tag name and time stamp.
         /// </summary>
-        public string Id { get; set; }
+        public string Id { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the tag that the annotation applies to.
         /// </summary>
         [Required]
-        public string TagName { get; set; }
+        public string TagName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the UTC timestamp for the annotation.
@@ -43,13 +43,13 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <returns>
         /// <see langword="true"/> if the two instances are equivalent, otherwise <see langword="false"/>.
         /// </returns>
-        public bool Equals(AnnotationIdentifier other) {
+        public bool Equals(AnnotationIdentifier? other) {
             if (other == null) {
                 return false;
             }
 
-            return String.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase) &&
-                   String.Equals(TagName, other.TagName, StringComparison.OrdinalIgnoreCase) &&
+            return string.Equals(Id, other.Id, StringComparison.OrdinalIgnoreCase) &&
+                   string.Equals(TagName, other.TagName, StringComparison.OrdinalIgnoreCase) &&
                    UtcAnnotationTime.Equals(other.UtcAnnotationTime);
         }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AnnotationUpdate.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AnnotationUpdate.cs
@@ -20,25 +20,25 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// Gets or sets the annotation identifier.  This also describes the tag that the annotation applies to, and the annotation time stamp.
         /// </summary>
         [Required]
-        public AnnotationIdentifier Identifier { get; set; }
+        public AnnotationIdentifier Identifier { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets a detailed description of the annotation.
         /// </summary>
         [MaxLength(MaximumDescriptionLength)]
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the annotation value.
         /// </summary>
         [Required]
         [MaxLength(MaximumValueLength)]
-        public string Value { get; set; }
+        public string Value { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the name of the user who last modified the annotation.
         /// </summary>
-        public string Modifier { get; set; }
+        public string? Modifier { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelElement.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelElement.cs
@@ -11,7 +11,7 @@ namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
         /// The parent ID of the element. Can be <see langword="null"/> if this is a top-level 
         /// element in the hierarchy.
         /// </summary>
-        public string ParentId { get; set; }
+        public string? ParentId { get; set; }
 
         /// <summary>
         /// A flag specifying if the element has children.
@@ -21,7 +21,7 @@ namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
         /// <summary>
         /// The child elements for this element.
         /// </summary>
-        public IEnumerable<AssetModelElement> Children { get; set; }
+        public IEnumerable<AssetModelElement>? Children { get; set; }
 
         /// <summary>
         /// A flag specifying if the element has properties.
@@ -31,7 +31,7 @@ namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
         /// <summary>
         /// The properties for the element.
         /// </summary>
-        public IEnumerable<AssetModelProperty> Properties { get; set; }
+        public IEnumerable<AssetModelProperty>? Properties { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelElementTemplate.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelElementTemplate.cs
@@ -15,7 +15,7 @@ namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
         /// <summary>
         /// The property templates associated with the element template.
         /// </summary>
-        public IEnumerable<AssetModelPropertyTemplate> Properties { get; set; }
+        public IEnumerable<AssetModelPropertyTemplate>? Properties { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelItemBase.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelItemBase.cs
@@ -11,30 +11,30 @@ namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
         /// The unique identifier for the model item.
         /// </summary>
         [Required]
-        public string Id { get; set; }
+        public string Id { get; set; } = default!;
 
         /// <summary>
         /// The name of the item.
         /// </summary>
         [Required]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// The description for the item.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// The template for the item. Can be <see langword="null"/> if the item does not use a 
         /// template.
         /// </summary>
-        public string TemplateId { get; set; }
+        public string? TemplateId { get; set; }
 
         /// <summary>
         /// The full address of the item.
         /// </summary>
         [Required]
-        public string Address { get; set; }
+        public string Address { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelProperty.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelProperty.cs
@@ -11,17 +11,17 @@ namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
         /// The ID of the <see cref="AssetModelElement"/> that the property belongs to.
         /// </summary>
         [Required]
-        public string ElementId { get; set; }
+        public string ElementId { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the unit of measure for the property.
         /// </summary>
-        public string UnitOfMeasure { get; set; }
+        public string? UnitOfMeasure { get; set; }
 
         /// <summary>
         /// The value of the property.
         /// </summary>
-        public object Value { get; set; }
+        public object? Value { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelPropertyTemplate.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelPropertyTemplate.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// The default unit of measure for the template.
         /// </summary>
-        public string UnitOfMeasure { get; set; }
+        public string? UnitOfMeasure { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelTemplateBase.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelTemplateBase.cs
@@ -11,18 +11,18 @@ namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
         /// The unique identifier for the template.
         /// </summary>
         [Required]
-        public string Id { get; set; }
+        public string Id { get; set; } = default!;
 
         /// <summary>
         /// The template name.
         /// </summary>
         [Required]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// The template description.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentConfiguration.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentConfiguration.cs
@@ -10,7 +10,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// The configuration settings for the component.
         /// </summary>
-        public IEnumerable<ComponentConfigurationSetting> Settings { get; set; }
+        public IEnumerable<ComponentConfigurationSetting>? Settings { get; set; }
 
     }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentConfigurationSetting.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentConfigurationSetting.cs
@@ -9,17 +9,17 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the setting category.
         /// </summary>
-        public string Category { get; set; }
+        public string Category { get; set; } = default!;
 
         /// <summary>
         /// Gets the setting display name.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the setting description.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the .NET CLR type name for the setting.
@@ -27,12 +27,12 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <remarks>
         /// The type name should be assembly qualified.
         /// </remarks>
-        public string TypeName { get; set; }
+        public string TypeName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the current setting value.
         /// </summary>
-        public string Value { get; set; }
+        public string? Value { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentInfo.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentInfo.cs
@@ -11,28 +11,28 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// Gets or sets the component name.
         /// </summary>
         [Required]
-        public ComponentName Name { get; set; }
+        public ComponentName Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the component description.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the component type name.
         /// </summary>
         [Required]
-        public string TypeName { get; set; }
+        public string TypeName { get; set; } = default!;
 
         /// <summary>
         /// Gets the current component status.
         /// </summary>
-        public ComponentStatus Status { get; set; }
+        public ComponentStatus Status { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the properties for the component.
         /// </summary>
-        public IDictionary<string, string> Properties { get; set; }
+        public IDictionary<string, string>? Properties { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentName.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentName.cs
@@ -12,30 +12,30 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// </summary>
         [Required]
         [MaxLength(200)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets the component namespace.
         /// </summary>
         [MaxLength(200)]
-        public string Namespace { get; set; }
+        public string? Namespace { get; set; }
 
         /// <summary>
         /// Gets the qualified component name.
         /// </summary>
-        public string QualifiedName { get { return GetQualifiedName(Name, Namespace); } }
+        public string? QualifiedName { get { return GetQualifiedName(Name, Namespace); } }
 
         /// <summary>
         /// The display name for the component.
         /// </summary>
-        private string _displayName;
+        private string? _displayName;
 
         /// <summary>
         /// Gets the display name for the component.
         /// </summary>
         [MaxLength(200)]
         public string DisplayName {
-            get { return String.IsNullOrWhiteSpace(_displayName) ? QualifiedName : _displayName; }
+            get { return string.IsNullOrWhiteSpace(_displayName) ? QualifiedName! : _displayName!; }
             set { _displayName = value; }
         }
 
@@ -46,17 +46,17 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <param name="name">The component name.</param>
         /// <param name="namespace">The component namespace.</param>
         /// <param name="displayName">The display name.</param>
-        public ComponentName(string name, string @namespace, string displayName) {
+        public ComponentName(string name, string? @namespace, string? displayName) {
             Name = name;
             Namespace = @namespace;
-            DisplayName = displayName;
+            _displayName = displayName;
         }
 
 
         /// <summary>
         /// Creates a new <see cref="ComponentName"/> object.
         /// </summary>
-        public ComponentName() : this(null, null, null) { }
+        public ComponentName() : this(null!, null, null) { }
 
         /// <summary>
         /// Creates a new <see cref="ComponentName"/> object from a single name string. Examine the name string syntax to determine if it is namespace qualified.
@@ -87,14 +87,14 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <returns>
         /// The qualified name, or <see langword="null"/> if <paramref name="name"/> is <see langword="null"/>.
         /// </returns>
-        public static string GetQualifiedName(string name, string @namespace) {
-            if (String.IsNullOrWhiteSpace(name)) {
-                return null;
+        public static string GetQualifiedName(string name, string? @namespace) {
+            if (string.IsNullOrWhiteSpace(name)) {
+                return null!;
             }
 
-            return String.IsNullOrWhiteSpace(@namespace)
+            return string.IsNullOrWhiteSpace(@namespace)
                        ? name
-                       : String.Concat(@namespace, ".", name);
+                       : string.Concat(@namespace, ".", name);
         }
 
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentStatus.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentStatus.cs
@@ -65,7 +65,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the health status of the component.
         /// </summary>
-        public ComponentHealth HealthStatus { get; private set; }
+        public ComponentHealth? HealthStatus { get; private set; }
 
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <param name="properties">A collection of component-specific properties.</param>
         /// <param name="healthStatus">The component's health status.</param>
         [JsonConstructor]
-        public ComponentStatus(ComponentRuntimeState runningStatus, bool isDebugMode, DateTime utcStartupTime, IEnumerable<LogMessage> messages, IEnumerable<NamedValue<string>> properties, ComponentHealth healthStatus) {
+        public ComponentStatus(ComponentRuntimeState runningStatus, bool isDebugMode, DateTime utcStartupTime, IEnumerable<LogMessage>? messages, IEnumerable<NamedValue<string>>? properties, ComponentHealth? healthStatus) {
             RunningStatus = runningStatus;
             UtcStartupTime = utcStartupTime.ToUniversalTime();
             DebugMode = isDebugMode;

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentTypeDescriptor.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentTypeDescriptor.cs
@@ -8,17 +8,17 @@
         /// <summary>
         /// The type name.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// The display name or description.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// The type version.
         /// </summary>
-        public string Version { get; set; }
+        public string? Version { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/EventMessage.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/EventMessage.cs
@@ -12,17 +12,17 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the ID for the event object.
         /// </summary>
-        public string ID { get; set; }
+        public string? ID { get; set; }
 
         /// <summary>
         /// Gets or sets the ID or name of the event source that generated the event.
         /// </summary>
-        public string SourceSystem { get; set; }
+        public string? SourceSystem { get; set; }
 
         /// <summary>
         /// Gets or sets the source identifier for the event.
         /// </summary>
-        public string Source { get; set; }
+        public string? Source { get; set; }
 
         /// <summary>
         /// Gets or sets the UTC event time.
@@ -32,12 +32,12 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the event category.
         /// </summary>
-        public string Category { get; set; }
+        public string? Category { get; set; }
 
         /// <summary>
         /// Gets or sets the event name.
         /// </summary>
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets a sequence number for the message.
@@ -51,12 +51,12 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the event message text.
         /// </summary>
-        public string Message { get; set; }
+        public string? Message { get; set; }
 
         /// <summary>
         /// The event properties.
         /// </summary>
-        private ICollection<EventProperty> _properties;
+        private ICollection<EventProperty> _properties = new List<EventProperty>();
 
         /// <summary>
         /// Gets or sets the event properties.
@@ -73,12 +73,12 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <remarks>
         /// For event sources such as control systems, this field should be populated with the message that was received from the source.
         /// </remarks>
-        public string RawMessage { get; set; }
+        public string? RawMessage { get; set; }
 
         /// <summary>
         /// The route that the event has taken to get to its current location.
         /// </summary>
-        private ICollection<EventRouteEntry> _route;
+        private ICollection<EventRouteEntry> _route = new List<EventRouteEntry>();
 
         /// <summary>
         /// Gets or sets the route that the event has taken to get to its current location.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/EventProperty.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/EventProperty.cs
@@ -7,12 +7,12 @@
         /// <summary>
         /// Gets or sets the event name.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the event value.
         /// </summary>
-        public object Value { get; set; }
+        public object? Value { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/EventRouteEntry.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/EventRouteEntry.cs
@@ -18,12 +18,12 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the name of the Data Core component that received the item.
         /// </summary>
-        public string ComponentName { get; set; }
+        public string ComponentName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the host name for the server that received the item.
         /// </summary>
-        public string HostName { get; set; }
+        public string HostName { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/EventSourceSubscription.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/EventSourceSubscription.cs
@@ -7,7 +7,7 @@
         /// <summary>
         /// Gets or sets the event source name.
         /// </summary>
-        public string EventSourceName { get; set; }
+        public string EventSourceName { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ExpressionTagReference.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ExpressionTagReference.cs
@@ -10,17 +10,17 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the display name for the reference.
         /// </summary>
-        public string DisplayName { get; set; }
+        public string DisplayName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the data source name.
         /// </summary>
-        public string DataSourceName { get; set; }
+        public string DataSourceName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the tag name.
         /// </summary>
-        public string TagName { get; set; }
+        public string TagName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets a flag stating if the tag reference could be resolved.
@@ -30,13 +30,13 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the reason that the expression is invalid, when <see cref="IsValid"/> is <see langword="false"/>.
         /// </summary>
-        public string ValidationError { get; set; }
+        public string? ValidationError { get; set; }
 
         /// <summary>
         /// Gets a key used in hash code generation and equality comparison.
         /// </summary>
         private string Key {
-            get { return String.Concat(DisplayName, ",", DataSourceName, ",", TagName).ToUpperInvariant(); }
+            get { return string.Concat(DisplayName, ",", DataSourceName, ",", TagName).ToUpperInvariant(); }
         }
 
 
@@ -58,7 +58,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <returns>
         /// <see langword="true"/> if the objects are equal, otherwise <see langword="false"/>.
         /// </returns>
-        public bool Equals(ExpressionTagReference obj) {
+        public bool Equals(ExpressionTagReference? obj) {
             if (obj == null) {
                 return false;
             }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ExpressionValidationResult.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ExpressionValidationResult.cs
@@ -10,7 +10,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the expression.
         /// </summary>
-        public string Expression { get; set; }
+        public string Expression { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets a flay stating if the expression is valid or not.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/GetAnnotationsRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/GetAnnotationsRequest.cs
@@ -11,25 +11,25 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// Gets or sets the data source name.
         /// </summary>
         [JsonProperty("dsn")]
-        public string Dsn { get; set; }
+        public string Dsn { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the tags.
         /// </summary>
         [JsonProperty("tags")]
-        public IEnumerable<string> Tags { get; set; }
+        public IEnumerable<string> Tags { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the query start time.
         /// </summary>
         [JsonProperty("start")]
-        public string Start { get; set; }
+        public string Start { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the query start time.
         /// </summary>
         [JsonProperty("end")]
-        public string End { get; set; }
+        public string End { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/HistoricalTagValues.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/HistoricalTagValues.cs
@@ -12,7 +12,7 @@ namespace IntelligentPlant.DataCore.Client.Model
         /// <summary>
         /// Gets or sets the tag name that the <see cref="Values"/> are for.
         /// </summary>
-        public string TagName { get; set; }
+        public string TagName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the display type to use when visualizing the <see cref="Values"/>.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/IEventMessage.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/IEventMessage.cs
@@ -9,37 +9,37 @@ namespace IntelligentPlant.DataCore.Client.Model {
     public interface IEventMessage {
 
         /// <summary>
-        /// Gets or sets the ID for the event object.
+        /// The ID for the event object.
         /// </summary>
-        string ID { get; }
+        string? ID { get; }
 
         /// <summary>
-        /// Gets or sets the ID or name of the event source that generated the event.
+        /// The ID or name of the event source that generated the event.
         /// </summary>
-        string SourceSystem { get; }
+        string? SourceSystem { get; }
 
         /// <summary>
-        /// Gets or sets the source identifier for the event.
+        /// The source identifier for the event.
         /// </summary>
-        string Source { get; }
+        string? Source { get; }
 
         /// <summary>
-        /// Gets or sets the UTC event time.
+        /// The UTC event time.
         /// </summary>
         DateTime UtcEventTime { get; }
 
         /// <summary>
-        /// Gets or sets the event category.
+        /// The event category.
         /// </summary>
-        string Category { get; }
+        string? Category { get; }
 
         /// <summary>
-        /// Gets or sets the event name.
+        /// The event name.
         /// </summary>
-        string Name { get; }
+        string? Name { get; }
 
         /// <summary>
-        /// Gets or sets a sequence number for the message.
+        /// The sequence number for the message.
         /// </summary>
         /// <remarks>
         /// This is an ordinal that can be used in conjunction with <see cref="UtcEventTime"/> to determine the order 
@@ -48,25 +48,25 @@ namespace IntelligentPlant.DataCore.Client.Model {
         long Seq { get; }
 
         /// <summary>
-        /// Gets or sets the event message text.
+        /// The event message text.
         /// </summary>
-        string Message { get; }
+        string? Message { get; }
 
         /// <summary>
-        /// Gets or sets the event properties.
+        /// The event properties.
         /// </summary>
         ICollection<EventProperty> Properties { get; }
 
         /// <summary>
-        /// Gets or sets the raw message from the event source.
+        /// The raw message from the event source.
         /// </summary>
         /// <remarks>
         /// For event sources such as control systems, this field should be populated with the message that was received from the source.
         /// </remarks>
-        string RawMessage { get; }
+        string? RawMessage { get; }
 
         /// <summary>
-        /// Gets or sets the route that the event has taken to get to its current location.
+        /// The route that the event has taken to get to its current location.
         /// </summary>
         ICollection<EventRouteEntry> Route { get; }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/IEventProperty.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/IEventProperty.cs
@@ -6,14 +6,14 @@
     public interface IEventProperty {
 
         /// <summary>
-        /// Gets the event name.
+        /// Gets the event property name.
         /// </summary>
         string Name { get; }
 
         /// <summary>
         /// Gets the event value.
         /// </summary>
-        object Value { get; }
+        object? Value { get; }
 
     }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/IntermediateTagValues.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/IntermediateTagValues.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
+#nullable disable
+
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes a data query result for a single tag, before it has been transformed.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/LogMessage.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/LogMessage.cs
@@ -17,7 +17,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the message.
         /// </summary>
-        public string Message { get; private set; }
+        public string? Message { get; private set; }
 
 
         /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Person.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Person.cs
@@ -19,17 +19,17 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// Gets or sets the person's name.
         /// </summary>
         [Required]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the person's email address.
         /// </summary>
-        public string Email { get; set; }
+        public string? Email { get; set; }
 
         /// <summary>
         /// Gets or sets the person's URL.
         /// </summary>
-        public Uri Url { get; set; }
+        public Uri? Url { get; set; }
 
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// A flag that indicates if <paramref name="result"/> was successfully created. When <see langword="false"/>, 
         /// <paramref name="result"/> will be <see langword="null"/>.
         /// </returns>
-        public static bool TryCreateFromPersonString(string personString, out Person result) {
+        public static bool TryCreateFromPersonString(string personString, out Person? result) {
             if (String.IsNullOrWhiteSpace(personString)) {
                 result = null;
                 return false;

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptEngine.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptEngine.cs
@@ -10,26 +10,26 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// Gets or sets the script engine ID.
         /// </summary>
         [Required]
-        public string Id { get; set; }
+        public string Id { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the display name for the script engine.
         /// </summary>
         [Required]
         [MaxLength(200)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the description for the script engine.
         /// </summary>
         [MaxLength(500)]
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the scripting language used by the engine.
         /// </summary>
         [MaxLength(50)]
-        public string Language { get; set; }
+        public string? Language { get; set; }
 
         /// <summary>
         /// Gets or sets a flag specifying if the script engine supports templating.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagArchiveSettings.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagArchiveSettings.cs
@@ -18,14 +18,14 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// Specifies the destination data source to write values to when <see cref="IsArchivingEnabled"/> 
         /// is <see langword="true"/>.
         /// </summary>
-        public string ArchivingDataSourceName { get; set; }
+        public string? ArchivingDataSourceName { get; set; }
 
         /// <summary>
         /// Specifies the destination tag name to write values to when <see cref="IsArchivingEnabled"/> is 
         /// <see langword="true"/>. A <see langword="null"/> or white space value means that a destination 
         /// tag name will be inferred.
         /// </summary>
-        public string ArchivingTagName { get; set; }
+        public string? ArchivingTagName { get; set; }
 
 
         /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagDefinition.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagDefinition.cs
@@ -11,12 +11,12 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// Gets or sets the ID of the script tag.
         /// </summary>
         [Required]
-        public string Id { get; set; }
+        public string Id { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the script tag metadata.
         /// </summary>
-        public ScriptTagMetadata Metadata { get; set; }
+        public ScriptTagMetadata? Metadata { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagEventDefinition.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagEventDefinition.cs
@@ -18,19 +18,19 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// Gets or sets the namespace for the event. If not specified, the name of the script tag will be used.
         /// </summary>
         [MaxLength(200)]
-        public string Namespace { get; set; }
+        public string? Namespace { get; set; }
 
         /// <summary>
         /// Gets or sets the category for the event.
         /// </summary>
         [MaxLength(100)]
-        public string Category { get; set; }
+        public string? Category { get; set; }
 
         /// <summary>
         /// Gets or sets the description for the event.
         /// </summary>
         [MaxLength(500)]
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets a flag specifying if the event must reset before it can trigger again.
@@ -43,13 +43,13 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// Gets or sets a URL that can be visited to find out more information about an event.
         /// </summary>
         [MaxLength(500)]
-        public string MoreInfoUrl { get; set; }
+        public string? MoreInfoUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the caption to use for "more info" links.
         /// </summary>
         [MaxLength(50)]
-        public string MoreInfoCaption { get; set; }
+        public string? MoreInfoCaption { get; set; }
 
     }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagMetadata.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagMetadata.cs
@@ -10,7 +10,7 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// <summary>
         /// Gets or sets the ID of the script engine that the script tag should use.
         /// </summary>
-        public string ScriptEngineId { get; set; }
+        public string ScriptEngineId { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets a flag indicating if the script tag was created using a template.
@@ -20,17 +20,17 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// <summary>
         /// Gets or sets the name of the application that created the tag.
         /// </summary>
-        public string ApplicationName { get; set; }
+        public string ApplicationName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets information about the user who owns the tag.
         /// </summary>
-        public UserInfo Owner { get; set; }
+        public UserInfo? Owner { get; set; }
 
         /// <summary>
         /// Gets or sets the user who created the tag.
         /// </summary>
-        public UserInfo Creator { get; set; }
+        public UserInfo? Creator { get; set; }
 
         /// <summary>
         /// Gets or sets the UTC creation time for the tag.
@@ -40,7 +40,7 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// <summary>
         /// Gets or sets the user who last modified the tag.
         /// </summary>
-        public UserInfo LastModifiedBy { get; set; }
+        public UserInfo? LastModifiedBy { get; set; }
 
         /// <summary>
         /// Gets or sets the UTC last modified time for the tag.
@@ -55,12 +55,12 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
             /// <summary>
             /// Gets or sets the user ID.
             /// </summary>
-            public string Id { get; set; }
+            public string Id { get; set; } = default!;
 
             /// <summary>
             /// Gets or sets the user name.
             /// </summary>
-            public string Name { get; set; }
+            public string Name { get; set; } = default!;
 
         }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagSettings.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagSettings.cs
@@ -14,13 +14,13 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// </summary>
         [Required]
         [MaxLength(200)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the tag description.
         /// </summary>
         [MaxLength(200)]
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets a flag that indicates if the script tag is enabled or disabled. Disabled script 
@@ -34,19 +34,19 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// Gets or sets the tag units.
         /// </summary>
         [MaxLength(50)]
-        public string Units { get; set; }
+        public string? Units { get; set; }
 
         /// <summary>
         /// Gets or sets the labels associated with the script tag.
         /// </summary>
         [MaxLength(20)]
-        public string[] Labels { get; set; }
+        public string[]? Labels { get; set; }
 
         /// <summary>
         /// Gets or sets the archive settings for the tag. Archiving must be enabled if you want to 
         /// perform historical queries on the script tag.
         /// </summary>
-        public ScriptTagArchiveSettings ArchiveSettings { get; set; }
+        public ScriptTagArchiveSettings? ArchiveSettings { get; set; }
 
     }
 
@@ -61,14 +61,14 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// </summary>
         [Required]
         [MaxLength(50)]
-        public string ScriptEngineId { get; set; }
+        public string ScriptEngineId { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the name of the application that is creating the tag.
         /// </summary>
         [Required]
         [MaxLength(100)]
-        public string ApplicationName { get; set; }
+        public string ApplicationName { get; set; } = default!;
 
         /// <summary>
         /// The initial start time for the script tag calculation, used on the first evaluation of 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagSettingsBase.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagSettingsBase.cs
@@ -16,14 +16,14 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// references can be specified. Each key can be up to <see cref="MaximumTagReferenceNameLength"/> 
         /// in length and must match <see cref="TagReferenceNameRegex"/>.
         /// </summary>
-        public IDictionary<string, TagReference> TagReferences { get; set; }
+        public IDictionary<string, TagReference>? TagReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the digital states for the script tag. Up to <see cref="MaximumDigitalStateCount"/> 
         /// states can be specified. Each key can be up to <see cref="MaximumDigitalStateNameLength"/> 
         /// in length.
         /// </summary>
-        public IDictionary<string, int> DigitalStates { get; set; }
+        public IDictionary<string, int>? DigitalStates { get; set; }
 
         /// <summary>
         /// Gets or sets a flag the indicates if the tag is allowed to trigger or reset events.
@@ -35,18 +35,18 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// to <see cref="MaximumEventDefinitionCount"/> event definitions can be defined. Each key can 
         /// be up to <see cref="MaximumEventDefinitionNameLength"/> in length.
         /// </summary>
-        public IDictionary<string, ScriptTagEventDefinition> EventDefinitions { get; set; }
+        public IDictionary<string, ScriptTagEventDefinition>? EventDefinitions { get; set; }
 
         /// <summary>
         /// Gets or sets additional properties for the tag.
         /// </summary>
-        public IDictionary<string, string> Properties { get; set; }
+        public IDictionary<string, string>? Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the settings for the tag's value script.
         /// </summary>
         [Required]
-        public ScriptTagValueScriptSettings ValueScript { get; set; }
+        public ScriptTagValueScriptSettings ValueScript { get; set; } = default!;
 
         #region [ Fields/properties to assist with validation ]
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagValueScriptSettings.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagValueScriptSettings.cs
@@ -16,7 +16,7 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// </summary>
         [Required]
         [MaxLength(2000)]
-        public string Script { get; set; }
+        public string Script { get; set; } = default!;
 
         /// <summary>
         /// The trigger type used to trigger recalculation.
@@ -28,7 +28,7 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// this is the CRON schedule to recalculate the script tag's value at. 
         /// </summary>
         [MaxLength(100)]
-        public string Schedule { get; set; }
+        public string? Schedule { get; set; }
 
         /// <summary>
         /// Describes the type of input data that will be retrieved for tag references when 
@@ -42,13 +42,13 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// the script tag. <see cref="DataFunctions.CurrentValue"/>, <see cref="DataFunctions.Raw"/> 
         /// and <see cref="DataFunctions.Plot"/> cannot be specified here.
         /// </summary>
-        public string[] InputDataFunctions { get; set; }
+        public string[]? InputDataFunctions { get; set; }
 
         /// <summary>
         /// When <see cref="InputDataType"/> is <see cref="ScriptTagInputDataType.AggregatedValues"/>, 
         /// this is the sample interval used when requesting aggregated input data for the script tag.
         /// </summary>
-        public string InputDataSampleInterval { get; set; }
+        public string? InputDataSampleInterval { get; set; }
 
         /// <summary>
         /// This is the batch size to use when requesting input data for the script tag. For example, 
@@ -64,7 +64,7 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         /// referenced tags that represent the window leading up to the evaluation sample time, 
         /// instead of just the referenced tag values at the evaluation sample time.
         /// </summary>
-        public string InputDataWindowSize { get; set; }
+        public string? InputDataWindowSize { get; set; }
 
         /// <summary>
         /// Gets or sets a flag specifying if snapshot recalculations for the script tag should be 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/TagReference.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/TagReference.cs
@@ -15,7 +15,7 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         [Required]
         [JsonProperty("dsn")]
         [MaxLength(200)]
-        public string DataSourceName { get; set; }
+        public string DataSourceName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the tag name for the reference.
@@ -23,7 +23,7 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting {
         [Required]
         [JsonProperty("tag")]
         [MaxLength(200)]
-        public string TagName { get; set; }
+        public string TagName { get; set; } = default!;
 
         /// <summary>
         /// Controls which property of incoming <see cref="TagValue"/> objects for the referenced 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplate.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplate.cs
@@ -13,44 +13,44 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
         /// </summary>
         [Required]
         [MaxLength(20)]
-        public string Language { get; set; }
+        public string Language { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the template category.
         /// </summary>
         [Required]
         [MaxLength(100)]
-        public string Category { get; set; }
+        public string Category { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the template name.
         /// </summary>
         [Required]
         [MaxLength(200)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the template description.
         /// </summary>
         [Required]
         [MaxLength(500)]
-        public string Description { get; set; }
+        public string Description { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the template version.
         /// </summary>
         [Required]
-        public string Version { get; set; }
+        public string Version { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the template author.
         /// </summary>
-        public Person Author { get; set; }
+        public Person? Author { get; set; }
 
         /// <summary>
         /// Gets or sets the template contributors.
         /// </summary>
-        public IEnumerable<Person> Contributors { get; set; }
+        public IEnumerable<Person>? Contributors { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplateParameterDefinition.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplateParameterDefinition.cs
@@ -18,25 +18,25 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
         /// </summary>
         [Required]
         [MaxLength(MaximumNameLength)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the friendly (display) name for the parameter.
         /// </summary>
         [MaxLength(200)]
-        public string FriendlyName { get; set; }
+        public string? FriendlyName { get; set; }
 
         /// <summary>
         /// Gets or sets the description for the parameter.
         /// </summary>
         [MaxLength(500)]
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the help link for the parameter.
         /// </summary>
         [MaxLength(200)]
-        public Uri HelpLink { get; set; }
+        public Uri? HelpLink { get; set; }
 
         /// <summary>
         /// Gets or sets the type of the parameter. This can be used to infer the type of editor that 
@@ -47,12 +47,12 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
         /// <summary>
         /// Gets or sets the default value for the parameter.
         /// </summary>
-        public object DefaultValue { get; set; }
+        public object? DefaultValue { get; set; }
 
         /// <summary>
         /// Gets or sets the validators for the parameter.
         /// </summary>
-        public IEnumerable<IDictionary<string, object>> Validators { get; set; }
+        public IEnumerable<IDictionary<string, object>>? Validators { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplateWithParameterDefinitions.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplateWithParameterDefinitions.cs
@@ -11,7 +11,7 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
         /// <summary>
         /// Gets or sets the parameters that are used in the template.
         /// </summary>
-        public IEnumerable<ScriptTemplateParameterDefinition> Parameters { get; set; }
+        public IEnumerable<ScriptTemplateParameterDefinition>? Parameters { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/TemplatedScriptTagSettings.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/TemplatedScriptTagSettings.cs
@@ -16,13 +16,13 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
         /// </summary>
         [Required]
         [MaxLength(200)]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the tag description.
         /// </summary>
         [MaxLength(200)]
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets a flag that indicates if the script tag is enabled or disabled. Disabled script 
@@ -36,32 +36,32 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
         /// Gets or sets the tag units.
         /// </summary>
         [MaxLength(50)]
-        public string Units { get; set; }
+        public string? Units { get; set; }
 
         /// <summary>
         /// Gets or sets the labels associated with the script tag.
         /// </summary>
         [MaxLength(20)]
-        public string[] Labels { get; set; }
+        public string[]? Labels { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the script template that the script tag uses.
         /// </summary>
         [Required]
         [MaxLength(200)]
-        public string TemplateName { get; set; }
+        public string TemplateName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the template parameters values that the script tag uses.
         /// </summary>
         [Required]
-        public IDictionary<string, object> TemplateParameters { get; set; }
+        public IDictionary<string, object> TemplateParameters { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the archive settings for the tag. Archiving must be enabled if you want to 
         /// perform historical queries on the script tag.
         /// </summary>
-        public ScriptTagArchiveSettings ArchiveSettings { get; set; }
+        public ScriptTagArchiveSettings? ArchiveSettings { get; set; }
 
 
         /// <summary>
@@ -95,14 +95,14 @@ namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
         /// </summary>
         [Required]
         [MaxLength(50)]
-        public string ScriptEngineId { get; set; }
+        public string ScriptEngineId { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the name of the application that is creating the tag.
         /// </summary>
         [Required]
         [MaxLength(100)]
-        public string ApplicationName { get; set; }
+        public string ApplicationName { get; set; } = default!;
 
         /// <summary>
         /// The initial start time for the script tag calculation, used on the first evaluation of 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagDigitalState.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagDigitalState.cs
@@ -7,12 +7,12 @@
         /// <summary>
         /// Gets or sets the state name.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the description for the state.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the value for the state.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagProperty.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagProperty.cs
@@ -7,17 +7,17 @@
         /// <summary>
         /// Gets or sets the name of the property.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the category for the property.
         /// </summary>
-        public string Category { get; set; }
+        public string? Category { get; set; }
 
         /// <summary>
         /// Gets or sets the property description.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the numerical order number for the property.
@@ -31,7 +31,7 @@
         /// <summary>
         /// Gets or sets the property value.
         /// </summary>
-        public object Value { get; set; }
+        public object? Value { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchFilter.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchFilter.cs
@@ -23,24 +23,24 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// Gets or sets the tag name filter to use.
         /// </summary>
         [MaxLength(200)]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         /// <summary>
         /// Gets or sets the tag description filter to use.
         /// </summary>
         [MaxLength(200)]
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the tag unit filter to use.
         /// </summary>
         [MaxLength(200)]
-        public string Unit { get; set; }
+        public string? Unit { get; set; }
 
         /// <summary>
         /// Gets or sets the additional tag property filters to use.
         /// </summary>
-        public IDictionary<string, string> Other { get; set; }
+        public IDictionary<string, string>? Other { get; set; }
 
         /// <summary>
         /// Gets or sets the page size for the results.
@@ -54,7 +54,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <remarks>
         /// Setting <see cref="Page"/> to be less than 1 will automatically set the value to 1 instead.
         /// </remarks>
-        [Range(1, Int32.MaxValue)]
+        [Range(1, int.MaxValue)]
         public int Page { get; set; } = 1;
 
         /// <summary>
@@ -71,14 +71,14 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// </para>
         /// 
         /// </remarks>
-        public IEnumerable<string> Properties { get; set; }
+        public IEnumerable<string>? Properties { get; set; }
 
 
         /// <summary>
         /// Creates a new <see cref="TagSearchFilter"/> object using the specified name filter.
         /// </summary>
         /// <param name="name">The tag name filter.</param>
-        public TagSearchFilter(string name) : this(name, null, null) { }
+        public TagSearchFilter(string? name) : this(name, null, null) { }
 
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// </summary>
         /// <param name="name">The tag name filter.</param>
         /// <param name="description">The description filter.</param>
-        public TagSearchFilter(string name, string description) : this(name, description, null) { }
+        public TagSearchFilter(string? name, string? description) : this(name, description, null) { }
 
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <param name="name">The tag name filter.</param>
         /// <param name="description">The description filter.</param>
         /// <param name="unit">The tag unit filter.</param>
-        public TagSearchFilter(string name, string description, string unit) {
+        public TagSearchFilter(string? name, string? description, string? unit) {
             Name = name;
             Description = description;
             Unit = unit;

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchResult.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchResult.cs
@@ -12,23 +12,23 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the tag ID.
         /// </summary>
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         /// <summary>
         /// Gets or sets the tag name.
         /// </summary>
         [Required]
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the tag description.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// Gets or sets the tag's unit of measure.
         /// </summary>
-        public string UnitOfMeasure { get; set; }
+        public string? UnitOfMeasure { get; set; }
 
         /// <summary>
         /// Tag properties
@@ -68,7 +68,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// Creates a new <see cref="TagSearchResult"/> object that is a copy of an existing object.
         /// </summary>
         /// <param name="other">The existing tag definition to copy.</param>
-        public TagSearchResult(TagSearchResult other) {
+        public TagSearchResult(TagSearchResult? other) {
             if (other == null) {
                 return;
             }
@@ -90,7 +90,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <returns>
         /// The property value, or <paramref name="defaultValue"/> if the property is undefined, or if it cannot be cast to <typeparamref name="T"/>.
         /// </returns>
-        public T GetTagPropertyValue<T>(string name, T defaultValue) {
+        public T? GetTagPropertyValue<T>(string name, T defaultValue) {
             if (name == null) {
                 return defaultValue;
             }
@@ -101,7 +101,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
             }
 
             try {
-                return (T) prop.Value;
+                return (T?) prop.Value;
             }
             catch (InvalidCastException) {
                 return defaultValue;
@@ -117,7 +117,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <returns>
         /// The property value, or the default value of <typeparamref name="T"/> if the property is undefined or cannot be cast to <typeparamref name="T"/>.
         /// </returns>
-        public T GetTagPropertyValue<T>(string name) {
+        public T? GetTagPropertyValue<T>(string name) {
             return GetTagPropertyValue(name, default(T));
         }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchResultCollection.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchResultCollection.cs
@@ -10,7 +10,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the data source for the tags.
         /// </summary>
-        public ComponentName DataSourceName { get; set; }
+        public ComponentName DataSourceName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the tags.
@@ -20,12 +20,12 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets an error message to accompany the results if the tag search failed.
         /// </summary>
-        public string Error { get; set; }
+        public string? Error { get; set; }
 
         /// <summary>
         /// Flags if <see cref="Error"/> contains an error message.
         /// </summary>
-        public bool HasError { get { return !String.IsNullOrWhiteSpace(Error); } }
+        public bool HasError { get { return !string.IsNullOrWhiteSpace(Error); } }
 
 
         /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValue.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValue.cs
@@ -35,7 +35,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <remarks>
         /// For digital tags, this field returns the name of the digital state.
         /// </remarks>
-        public string TextValue { get; private set; }
+        public string? TextValue { get; private set; }
 
         /// <summary>
         /// Gets the quality status for the value.
@@ -45,17 +45,17 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets the unit of measure for the tag value.
         /// </summary>
-        public string Unit { get; private set; }
+        public string? Unit { get; private set; }
 
         /// <summary>
         /// Gets notes associated with the value.
         /// </summary>
-        public string Notes { get; private set; }
+        public string? Notes { get; private set; }
 
         /// <summary>
         /// Gets the error message associated with the value.
         /// </summary>
-        public string Error { get; private set; }
+        public string? Error { get; private set; }
 
         /// <summary>
         /// Gets a flag indicating if the tag value contains a numeric value.
@@ -84,7 +84,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <param name="notes">Additional notes about the value.</param>
         /// <param name="error">An error message associated with the value.</param>
         [JsonConstructor]
-        public TagValue(string tagName, DateTime utcSampleTime, double numericValue, string textValue, TagValueStatus status, string unit, string notes, string error) {
+        public TagValue(string tagName, DateTime utcSampleTime, double numericValue, string? textValue, TagValueStatus status, string? unit, string? notes, string? error) {
             TagName = tagName;
             UtcSampleTime = utcSampleTime;
             NumericValue = numericValue;
@@ -106,7 +106,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <param name="status">The quality status for the value.</param>
         /// <param name="unit">The unit of measure for the tag value.</param>
         /// <param name="notes">Additional notes about the value.</param>
-        public TagValue(string tagName, DateTime utcSampleTime, double numericValue, string textValue, TagValueStatus status, string unit, string notes) : this(tagName, utcSampleTime, numericValue, textValue, status, unit, notes, null) { }
+        public TagValue(string tagName, DateTime utcSampleTime, double numericValue, string? textValue, TagValueStatus status, string? unit, string? notes) : this(tagName, utcSampleTime, numericValue, textValue, status, unit, notes, null) { }
 
 
 
@@ -119,7 +119,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <param name="textValue">The text value.</param>
         /// <param name="status">The quality status for the value.</param>
         /// <param name="unit">The unit of measure for the tag value.</param>
-        public TagValue(string tagName, DateTime utcSampleTime, double numericValue, string textValue, TagValueStatus status, string unit) : this(tagName, utcSampleTime, numericValue, textValue, status, unit, null) { }
+        public TagValue(string tagName, DateTime utcSampleTime, double numericValue, string? textValue, TagValueStatus status, string? unit) : this(tagName, utcSampleTime, numericValue, textValue, status, unit, null) { }
 
 
         /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscription.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscription.cs
@@ -8,17 +8,17 @@
         /// <summary>
         /// Gets or sets the data source name.
         /// </summary>
-        public string DataSourceName { get; set; }
+        public string DataSourceName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the subscription group name.
         /// </summary>
-        public string GroupName { get; set; }
+        public string GroupName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the tag name.
         /// </summary>
-        public string TagName { get; set; }
+        public string TagName { get; set; } = default!;
 
     }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscriptionResult.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscriptionResult.cs
@@ -10,22 +10,22 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the data source name.
         /// </summary>
-        public string DataSourceName { get; set; }
+        public string DataSourceName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the data source's push notification group that the tags have been assigned to.
         /// </summary>
-        public string GroupName { get; set; }
+        public string GroupName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the registration results, indexed by tag name.
         /// </summary>
-        public IDictionary<string, TagValueSubscriptionResultItem> Result { get; set; }
+        public IDictionary<string, TagValueSubscriptionResultItem> Result { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets messages associated with the registration.
         /// </summary>
-        public IList<TagValueSubscriptionResultMessage> Messages { get; set; }
+        public IList<TagValueSubscriptionResultMessage> Messages { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the time taken to perform the registration.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscriptionResultItem.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscriptionResultItem.cs
@@ -10,7 +10,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the tag name.
         /// </summary>
-        public string TagName { get; set; }
+        public string TagName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the registration status.
@@ -25,12 +25,12 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the registration messages for the tag.
         /// </summary>
-        public IList<string> Messages { get; set; }
+        public IList<string>? Messages { get; set; }
 
         /// <summary>
         /// Gets or sets the value of the tag when the subscription was created.
         /// </summary>
-        public TagValue Value { get; set; }
+        public TagValue? Value { get; set; }
 
 
         /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscriptionResultMessage.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscriptionResultMessage.cs
@@ -7,12 +7,12 @@
         /// <summary>
         /// Gets or sets the message category.
         /// </summary>
-        public string Category { get; set; }
+        public string? Category { get; set; }
 
         /// <summary>
         /// Gets or sets the message.
         /// </summary>
-        public object Message { get; set; }
+        public object? Message { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdate.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdate.cs
@@ -14,7 +14,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the sample value.
         /// </summary>
-        public object Value { get; set; }
+        public object Value { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets the sample quality status.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdateCollection.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdateCollection.cs
@@ -11,7 +11,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// Gets or sets the tag name.
         /// </summary>
         [Required]
-        public string TagName { get; set; }
+        public string TagName { get; set; } = default!;
 
         /// <summary>
         /// The sample values.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdateResponse.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdateResponse.cs
@@ -9,7 +9,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets the tag name.
         /// </summary>
-        public string TagName { get; set; }
+        public string TagName { get; set; } = default!;
 
         /// <summary>
         /// Gets or sets a flag indicating if the write was successful.
@@ -19,7 +19,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// <summary>
         /// Gets or sets a collection of messages associated with the write.
         /// </summary>
-        public ICollection<string> Messages { get; set; }
+        public ICollection<string>? Messages { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValuesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValuesRequest.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 
 using Newtonsoft.Json;
 
+#nullable disable
+
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes a tag values request to be sent to Data Core.

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/CreateAnnotationRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/CreateAnnotationRequest.cs
@@ -5,10 +5,10 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class CreateAnnotationRequest {
 
         [Required]
-        public string DataSourceName { get; set; }
+        public string DataSourceName { get; set; } = default!;
 
         [Required]
-        public Annotation Annotation { get; set; }
+        public Annotation Annotation { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/CreateScriptTagRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/CreateScriptTagRequest.cs
@@ -6,7 +6,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class CreateScriptTagRequest : DataSourceRequest {
 
         [Required]
-        public CreateScriptTagSettings Settings { get; set; }
+        public CreateScriptTagSettings Settings { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/CreateTemplatedScriptTagRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/CreateTemplatedScriptTagRequest.cs
@@ -7,7 +7,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class CreateTemplatedScriptTagRequest : DataSourceRequest {
 
         [Required]
-        public CreateTemplatedScriptTagSettings Settings { get; set; }
+        public CreateTemplatedScriptTagSettings Settings { get; set; } = default!;
 
     }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/CustomFunctionRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/CustomFunctionRequest.cs
@@ -13,19 +13,19 @@ namespace IntelligentPlant.DataCore.Client.Model.Queries {
         /// Gets or sets the component name to send the custom function to. Leave blank for 
         /// general-purpose custom function messages.
         /// </summary>
-        public string ComponentName { get; set; }
+        public string? ComponentName { get; set; }
 
         /// <summary>
         /// The name of the custom function to call.
         /// </summary>
         [Required]
         [MaxLength(200)]
-        public string MethodName { get; set; }
+        public string MethodName { get; set; } = default!;
 
         /// <summary>
         /// The function parameters.
         /// </summary>
-        public IDictionary<string, string> Parameters { get; set; }
+        public IDictionary<string, string>? Parameters { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/DataSourceRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/DataSourceRequest.cs
@@ -4,7 +4,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class DataSourceRequest {
 
         [Required]
-        public string DataSourceName { get; set; }
+        public string DataSourceName { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/DeleteAnnotationRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/DeleteAnnotationRequest.cs
@@ -6,10 +6,10 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class DeleteAnnotationRequest {
 
         [Required]
-        public string DataSourceName { get; set; }
+        public string DataSourceName { get; set; } = default!;
 
         [Required]
-        public AnnotationIdentifier Annotation { get; set; }
+        public AnnotationIdentifier Annotation { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/DeleteScriptTagRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/DeleteScriptTagRequest.cs
@@ -4,7 +4,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class DeleteScriptTagRequest : DataSourceRequest {
 
         [Required]
-        public string ScriptTagId { get; set; }
+        public string ScriptTagId { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/EventSinkRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/EventSinkRequest.cs
@@ -4,7 +4,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class EventSinkRequest {
 
         [Required]
-        public string EventSinkName { get; set; }
+        public string EventSinkName { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/EventSourceRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/EventSourceRequest.cs
@@ -4,7 +4,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class EventSourceRequest {
 
         [Required]
-        public string EventSourceName { get; set; }
+        public string EventSourceName { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/FindAssetModelElementTemplatesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/FindAssetModelElementTemplatesRequest.cs
@@ -11,7 +11,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
         /// The template name filter to apply.
         /// </summary>
         [MaxLength(200)]
-        public string NameFilter { get; set; }
+        public string? NameFilter { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/FindAssetModelElementsRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/FindAssetModelElementsRequest.cs
@@ -3,13 +3,13 @@
 namespace IntelligentPlant.DataCore.Client.Queries {
     public class FindAssetModelElementsRequest : DataSourceRequest {
 
-        public string ParentId { get; set; }
+        public string? ParentId { get; set; }
 
         [MaxLength(200)]
-        public string NameFilter { get; set; }
+        public string? NameFilter { get; set; }
 
         [MaxLength(200)]
-        public string PropertyNameFilter { get; set; }
+        public string? PropertyNameFilter { get; set; }
 
         public bool LoadProperties { get; set; }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/FindAssetModelPropertyTemplatesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/FindAssetModelPropertyTemplatesRequest.cs
@@ -11,7 +11,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
         /// The ID of the element template to retrieve the properties for.
         /// </summary>
         [Required]
-        public string Id { get; set; }
+        public string Id { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/FindScriptTagTemplatesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/FindScriptTagTemplatesRequest.cs
@@ -9,7 +9,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
 
         [Required]
         [MaxLength(100)]
-        public string ScriptEngineId { get; set; }
+        public string ScriptEngineId { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/FindTagsRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/FindTagsRequest.cs
@@ -6,7 +6,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class FindTagsRequest : DataSourceRequest {
 
         [Required]
-        public TagSearchFilter Filter { get; set; }
+        public TagSearchFilter Filter { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/GetAssetModelElementRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/GetAssetModelElementRequest.cs
@@ -4,7 +4,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class GetAssetModelElementRequest : DataSourceRequest {
 
         [Required]
-        public string Id { get; set; }
+        public string Id { get; set; } = default!;
 
         public bool LoadProperties { get; set; }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/GetAssetModelElementTemplateRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/GetAssetModelElementTemplateRequest.cs
@@ -11,7 +11,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
         /// The template ID.
         /// </summary>
         [Required]
-        public string Id { get; set; }
+        public string Id { get; set; } = default!;
 
     }
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/GetScriptTagTemplateRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/GetScriptTagTemplateRequest.cs
@@ -9,11 +9,11 @@ namespace IntelligentPlant.DataCore.Client.Queries {
 
         [Required]
         [MaxLength(100)]
-        public string ScriptEngineId { get; set; }
+        public string ScriptEngineId { get; set; } = default!;
 
         [Required]
         [MaxLength(100)]
-        public string TemplateId { get; set; }
+        public string TemplateId { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/GetTagRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/GetTagRequest.cs
@@ -4,7 +4,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class GetTagRequest : DataSourceRequest {
 
         [Required]
-        public string TagNameOrId { get; set; }
+        public string TagNameOrId { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/GetTagsRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/GetTagsRequest.cs
@@ -8,7 +8,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
         [Required]
         [MinLength(1)]
         [MaxLength(100)]
-        public string[] TagNamesOrIds { get; set; }
+        public string[] TagNamesOrIds { get; set; } = default!;
 
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/IsAuthorizedOnDataSourceRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/IsAuthorizedOnDataSourceRequest.cs
@@ -5,7 +5,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
 
         [Required]
         [MinLength(1)]
-        public string[] RoleNames { get; set; }
+        public string[] RoleNames { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/IsAuthorizedOnEventSinkRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/IsAuthorizedOnEventSinkRequest.cs
@@ -5,7 +5,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
 
         [Required]
         [MinLength(1)]
-        public string[] RoleNames { get; set; }
+        public string[] RoleNames { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/IsAuthorizedOnEventSourceRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/IsAuthorizedOnEventSourceRequest.cs
@@ -5,7 +5,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
 
         [Required]
         [MinLength(1)]
-        public string[] RoleNames { get; set; }
+        public string[] RoleNames { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadAnnotationsRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadAnnotationsRequest.cs
@@ -16,7 +16,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
         /// </summary>
         [Required]
         [JsonProperty("dsn")]
-        public string DataSourceName { get; set; }
+        public string DataSourceName { get; set; } = default!;
 
         /// <summary>
         /// The tags to request annotations from.
@@ -24,7 +24,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
         [Required]
         [MinLength(1)]
         [JsonProperty("tags")]
-        public string[] TagNames { get; set; }
+        public string[] TagNames { get; set; } = default!;
 
         /// <summary>
         /// The UTC start time for the query.

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadProcessedTagValuesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadProcessedTagValuesRequest.cs
@@ -14,7 +14,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
         /// commonly-supported function names.
         /// </summary>
         [Required]
-        public string DataFunction { get; set; }
+        public string DataFunction { get; set; } = default!;
 
         /// <summary>
         /// The sample interval to use when processing the tag values.

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadTagValuesAtTimesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadTagValuesAtTimesRequest.cs
@@ -13,7 +13,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
         /// </summary>
         [Required]
         [MinLength(1)]
-        public DateTime[] UtcSampleTimes { get; set; }
+        public DateTime[] UtcSampleTimes { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadTagValuesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadTagValuesRequest.cs
@@ -14,12 +14,12 @@ namespace IntelligentPlant.DataCore.Client.Queries {
         /// The tags to query, indexed by data source name.
         /// </summary>
         [Required]
-        public IDictionary<string, string[]> Tags { get; set; }
+        public IDictionary<string, string[]> Tags { get; set; } = default!;
 
         /// <summary>
         /// Additional custom query properties.
         /// </summary>
-        public IDictionary<string, string> QueryProperties { get; set; }
+        public IDictionary<string, string>? QueryProperties { get; set; }
 
         /// <summary>
         /// Validates the object.

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/UpdateAnnotationRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/UpdateAnnotationRequest.cs
@@ -6,10 +6,10 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class UpdateAnnotationRequest {
 
         [Required]
-        public string DataSourceName { get; set; }
+        public string DataSourceName { get; set; } = default!;
 
         [Required]
-        public AnnotationUpdate Annotation { get; set; }
+        public AnnotationUpdate Annotation { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/UpdateScriptTagRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/UpdateScriptTagRequest.cs
@@ -6,9 +6,10 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class UpdateScriptTagRequest : DataSourceRequest {
 
         [Required]
-        public string ScriptTagId { get; set; }
+        public string ScriptTagId { get; set; } = default!;
 
-        public ScriptTagSettings Settings { get; set; }
+        [Required]
+        public ScriptTagSettings Settings { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/UpdateTemplatedScriptTagRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/UpdateTemplatedScriptTagRequest.cs
@@ -6,9 +6,10 @@ namespace IntelligentPlant.DataCore.Client.Queries {
     public class UpdateTemplatedScriptTagRequest : DataSourceRequest {
 
         [Required]
-        public string ScriptTagId { get; set; }
+        public string ScriptTagId { get; set; } = default!;
 
-        public TemplatedScriptTagSettings Settings { get; set; }
+        [Required]
+        public TemplatedScriptTagSettings Settings { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/WriteTagValuesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/WriteTagValuesRequest.cs
@@ -9,7 +9,7 @@ namespace IntelligentPlant.DataCore.Client.Queries {
 
         [Required]
         [MinLength(1)]
-        public TagValue[] Values { get; set; }
+        public TagValue[] Values { get; set; } = default!;
 
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) {

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/ClaimsPrincipalExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/ClaimsPrincipalExtensions.cs
@@ -17,7 +17,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ///   The value of the principal's <see cref="ClaimTypes.NameIdentifier"/> 
         ///   claim, or <see langword="null"/> if the claim was not found.
         /// </returns>
-        public static string GetUserId(this ClaimsPrincipal principal) {
+        public static string? GetUserId(this ClaimsPrincipal principal) {
             return principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         }
 
@@ -32,7 +32,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ///   The value of the principal's <see cref="ClaimTypes.Name"/> 
         ///   claim, or <see langword="null"/> if the claim was not found.
         /// </returns>
-        public static string GetUserName(this ClaimsPrincipal principal) {
+        public static string? GetUserName(this ClaimsPrincipal principal) {
             return principal?.FindFirst(ClaimTypes.Name)?.Value;
         }
 
@@ -47,7 +47,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ///   The value of the principal's <see cref="IndustrialAppStoreAuthenticationDefaults.OrgNameClaimType"/> 
         ///   claim, or <see langword="null"/> if the claim was not found.
         /// </returns>
-        public static string GetOrganisationName(this ClaimsPrincipal principal) {
+        public static string? GetOrganisationName(this ClaimsPrincipal principal) {
             return principal?.FindFirst(IndustrialAppStoreAuthenticationDefaults.OrgNameClaimType)?.Value;
         }
 
@@ -62,7 +62,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ///   The value of the principal's <see cref="IndustrialAppStoreAuthenticationDefaults.OrgIdentifierClaimType"/> 
         ///   claim, or <see langword="null"/> if the claim was not found.
         /// </returns>
-        public static string GetOrganisationId(this ClaimsPrincipal principal) {
+        public static string? GetOrganisationId(this ClaimsPrincipal principal) {
             return principal?.FindFirst(IndustrialAppStoreAuthenticationDefaults.OrgIdentifierClaimType)?.Value;
         }
 
@@ -77,7 +77,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ///   The value of the principal's <see cref="IndustrialAppStoreAuthenticationDefaults.PictureClaimType"/> 
         ///   claim, or <see langword="null"/> if the claim was not found.
         /// </returns>
-        public static string GetProfilePictureUrl(this ClaimsPrincipal principal) {
+        public static string? GetProfilePictureUrl(this ClaimsPrincipal principal) {
             return principal?.FindFirst(IndustrialAppStoreAuthenticationDefaults.PictureClaimType)?.Value;
         }
 
@@ -92,7 +92,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ///   The value of the principal's <see cref="IndustrialAppStoreAuthenticationDefaults.AppSessionIdClaimType"/> 
         ///   claim, or <see langword="null"/> if the claim was not found.
         /// </returns>
-        public static string GetSessionId(this ClaimsPrincipal principal) { 
+        public static string? GetSessionId(this ClaimsPrincipal principal) { 
             return principal?.FindFirst(IndustrialAppStoreAuthenticationDefaults.AppSessionIdClaimType)?.Value;
         }
 

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/DefaultTokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/DefaultTokenStore.cs
@@ -17,7 +17,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <summary>
         /// The authentication session to store tokens in.
         /// </summary>
-        private AuthenticationProperties _authenticationProperties;
+        private AuthenticationProperties? _authenticationProperties;
 
 
         /// <summary>
@@ -39,6 +39,33 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ) : base(options, httpClient, clock) { }
 
 
+        /// <summary>
+        /// Initialises the <see cref="DefaultTokenStore"/>.
+        /// </summary>
+        /// <param name="userId">
+        ///   The user ID.
+        /// </param>
+        /// <param name="sessionId">
+        ///   The session ID.
+        /// </param>
+        /// <param name="authenticationProperties">
+        ///   The authentication properties for the session.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask"/> that will initialise the <see cref="DefaultTokenStore"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="userId"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="sessionId"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="authenticationProperties"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   The token store has already been initialised.
+        /// </exception>
         public async ValueTask InitAsync(string userId, string sessionId, AuthenticationProperties authenticationProperties) {
             if (authenticationProperties == null) {
                 throw new ArgumentNullException(nameof(authenticationProperties));
@@ -76,7 +103,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
 
             var refreshToken = _authenticationProperties.GetTokenValue(IndustrialAppStoreAuthenticationDefaults.RefreshTokenName);
 
-            return new ValueTask<OAuthTokens?>(new OAuthTokens(tokenType, accessToken, refreshToken, accessTokenExpiry));
+            return new ValueTask<OAuthTokens?>(new OAuthTokens(tokenType!, accessToken, refreshToken!, accessTokenExpiry));
         }
 
 

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/HttpClientExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/HttpClientExtensions.cs
@@ -27,7 +27,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
             tokenRequestParameters["client_secret"] = options.ClientSecret;
 #endif
 
-            var refreshRequestContent = new FormUrlEncodedContent(tokenRequestParameters);
+            var refreshRequestContent = new FormUrlEncodedContent(tokenRequestParameters!);
             var refreshRequest = new HttpRequestMessage(HttpMethod.Post, options.GetTokenEndpoint()) {
                 Content = refreshRequestContent
             };

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Security.Claims;
 
 using IntelligentPlant.IndustrialAppStore.Client;
 
@@ -56,12 +57,12 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <summary>
         /// The Industrial App Store client ID.
         /// </summary>
-        public string ClientId { get; set; }
+        public string ClientId { get; set; } = default!;
 
         /// <summary>
         /// The Industrial App Store client secret.
         /// </summary>
-        public string ClientSecret { get; set; }
+        public string? ClientSecret { get; set; }
 
         /// <summary>
         /// The OAuth scopes to request.
@@ -99,7 +100,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// registration used by the <see cref="IndustrialAppStoreHttpClient"/> application 
         /// service.
         /// </summary>
-        public Action<IHttpClientBuilder> ConfigureHttpClient { get; set; }
+        public Action<IHttpClientBuilder>? ConfigureHttpClient { get; set; }
 
         /// <summary>
         /// Additional event handlers for cookie authentication events raised by the application.
@@ -107,7 +108,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <remarks>
         ///   Ignored when <see cref="UseExternalAuthentication"/> is <see langword="true"/>.
         /// </remarks>
-        public CookieAuthenticationEvents CookieAuthenticationEvents { get; set; }
+        public CookieAuthenticationEvents? CookieAuthenticationEvents { get; set; }
 
         /// <summary>
         /// Additional event handlers for OAuth authentication events raised when signing a user 
@@ -116,7 +117,28 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <remarks>
         ///   Ignored when <see cref="UseExternalAuthentication"/> is <see langword="true"/>.
         /// </remarks>
-        public OAuthEvents OAuthEvents { get; set; }
+        public OAuthEvents? OAuthEvents { get; set; }
+
+        /// <summary>
+        /// A callback that can be used to generate an ID for a new session from the provided 
+        /// <see cref="ClaimsIdentity"/> and <see cref="HttpContext"/>.
+        /// </summary>
+        /// <remarks>
+        /// 
+        /// <para>
+        ///   Specify a value for <see cref="SessionIdGenerator"/> if your app nees to customise 
+        ///   how an identifier is generated for a session (for example, by computing a fingerprint 
+        ///   based on the user/device/browser combination).
+        /// </para>
+        /// 
+        /// <para>
+        ///   If <see cref="SessionIdGenerator"/> is <see langword="null"/> or returns a 
+        ///   <see langword="null"/> or white space value, a unique identifier will be generated 
+        ///   for the session.
+        /// </para>
+        /// 
+        /// </remarks>
+        public Func<ClaimsIdentity, HttpContext, string>? SessionIdGenerator { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreHttpClient.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreHttpClient.cs
@@ -100,7 +100,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ///   A <see cref="Task{TResult}"/> that will return a flag indiciating if a valid access 
         ///   token is available.
         /// </returns>
-        public async Task<bool> HasValidAccessToken(HttpContext context) {
+        public static async Task<bool> HasValidAccessToken(HttpContext context) {
             if (context == null) {
                 throw new ArgumentNullException(nameof(context));
             }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/OAuthTokens.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/OAuthTokens.cs
@@ -23,7 +23,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <summary>
         /// The refresh token for the authenticated user. Can be <see langword="null"/>.
         /// </summary>
-        public string RefreshToken { get; }
+        public string? RefreshToken { get; }
 
         /// <summary>
         /// The UTC expiry time for the <see cref="AccessToken"/>. Can be <see langword="null"/> 
@@ -50,7 +50,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="accessToken"/> is <see langword="null"/>.
         /// </exception>
-        public OAuthTokens(string tokenType, string accessToken, string refreshToken, DateTimeOffset? utcExpiresAt) {
+        public OAuthTokens(string tokenType, string accessToken, string? refreshToken, DateTimeOffset? utcExpiresAt) {
             TokenType = tokenType;
             AccessToken = accessToken ?? throw new ArgumentNullException(nameof(accessToken));
             RefreshToken = refreshToken;

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/README.md
@@ -114,7 +114,7 @@ public class ExampleController : ControllerBase {
         [FromServices] IndustrialAppStoreHttpClient iasClient,
         CancellationToken cancellationToken
     ) {
-        var hasAccessToken = await iasClient.HasValidAccessToken(Request.HttpContext);
+        var hasAccessToken = await IndustrialAppStoreHttpClient.HasValidAccessToken(Request.HttpContext);
         if (!hasAccessToken) {
             // User does not have a valid access token.
             return NotAuthorized();
@@ -131,7 +131,9 @@ public class ExampleController : ControllerBase {
 
 `BackchannelIndustrialAppStoreHttpClient` expects an [ITokenStore](./ITokenStore.cs) to be passed when making calls to the Industrial App Store. The access token is retrieved from the `ITokenStore` and appended to the outgoing HTTP request headers. 
 
-This allows you to make calls to the Industrial App Store from outside the app's HTTP request pipeline, such as from a background task or an `IHostedService`. For example, your app might allow a user to configure a periodic task that will perform some anaylsis on an industrial process in the background, regardless of whether or not the user has the app open in their browser:
+This allows you to make calls to the Industrial App Store from outside the app's HTTP request pipeline, such as from a background task or an `IHostedService`. For example, your app might allow a user to configure a periodic task that will perform some anaylsis on an industrial process in the background, regardless of whether or not the user has the app open in their browser.
+
+Note that this scenario requires that you are using a custom `ITokenStore` implementation in your app, so that you can persist access tokens to a location other than the browser's session cookie. See 'Using a Custom Token Store' below for details.
 
 ```csharp
 public class MyAnalysis {
@@ -161,7 +163,33 @@ public class MyAnalysis {
 }
 ```
 
-Note that this scenario requires that you are using a custom `ITokenStore` implementation in your app, so that you can persist access tokens to a location other than the browser's session cookie. See below for details.
+It is also possible to use `BackchannelIndustrialAppStoreHttpClient` from inside the HTTP request pipeline if preferred. In this situation, you must manually retrieve the `ITokenStore` for the authenticated user from the current `HttpContext`. The equivalent API controller code above using `BackchannelIndustrialAppStoreHttpClient` instead of `IndustrialAppStoreHttpClient` would be as follows:
+
+
+```csharp
+[ApiController]
+public class ExampleController : ControllerBase {
+
+    [HttpGet]
+    [Authorize]
+    public async Task<IActionResult> GetIndustrialAppStoreDataSources(
+        [FromServices] BackchannelIndustrialAppStoreHttpClient iasClient,
+        CancellationToken cancellationToken
+    ) {
+        var tokenStore = Request.HttpContext.RequestServices.GetRequiredService<ITokenStore>();
+        var hasAccessToken = await BackchannelIndustrialAppStoreHttpClient.HasValidAccessToken(tokenStore);
+        if (!hasAccessToken) {
+            // User does not have a valid access token.
+            return NotAuthorized();
+        }
+
+        var dataSources = await iasClient.DataSources.GetDataSourcesAsync(tokenStore, cancellationToken);
+        return Ok(dataSources);
+    }
+
+}
+```
+
 
 
 # Using a Custom Token Store
@@ -170,12 +198,14 @@ The [ITokenStore](./ITokenStore.cs) service is used to store and retrieve Indust
 
 Under many circumstances, this approach is perfectly valid. However, if your application performs some sort of background data processing on behalf of a user (e.g. an app that periodically retrieves historian data, performs some calculations, and then writes the calculation results back to an Edge Historian), you will need to provide a custom `ITokenStore` implementation so that access tokens (and refresh tokens) can be persisted to somewhere other than a user's browser session cookie.
 
->> **NOTE:**
->> Access tokens and refresh tokens should be treated with the same level of security as passwords. They should never be persisted without being encrypted first.
+> **NOTE:**
+> Access tokens and refresh tokens should be treated with the same level of security as passwords. They should never be persisted without being encrypted first.
+
+When writing a custom `ITokenStore`, you should inherit from the abstract [TokenStore](./TokenStore.cs) base class.
 
 An example project showing how to write a custom `ITokenStore` implementation that uses Entity Framework Core to persist tokens to a SQLite database can be found [here](../../samples/CustomTokenStoreExample).
 
-When writing a custom `ITokenStore`, you can inherit from the abstract [TokenStore](./TokenStore.cs) base class. The custom token store type is then specified when adding Industrial App Store authentication to your project:
+Register your custom token store when adding Industrial App Store authentication to your project as follows:
 
 ```csharp
 services.AddIndustrialAppStoreAuthentication<MyCustomTokenStore>(options => {
@@ -202,4 +232,4 @@ services.AddIndustrialAppStoreAuthentication<MyCustomTokenStore>(
 );
 ```
 
->> The `ITokenStore` service is always registered as a *scoped* service.
+> The `ITokenStore` service is always registered as a *scoped* service.

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStore.cs
@@ -43,12 +43,12 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <summary>
         /// The user ID for the token store.
         /// </summary>
-        protected string UserId { get; private set; }
+        protected string? UserId { get; private set; }
 
         /// <summary>
         /// The session ID for the token store.
         /// </summary>
-        protected string SessionId { get; private set; }
+        protected string? SessionId { get; private set; }
 
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
             var tokens = await UseRefreshTokenAsync(
                 oauthTokens.Value.RefreshToken, 
                 _options.ClientId, 
-                _options.ClientSecret, 
+                _options.ClientSecret!, 
                 _options.GetTokenEndpoint(), 
                 _backchannelHttpClient, 
                 _clock
@@ -244,7 +244,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
                 tokenRequestParameters["client_secret"] = clientSecret;
             }
 
-            var refreshRequestContent = new FormUrlEncodedContent(tokenRequestParameters);
+            var refreshRequestContent = new FormUrlEncodedContent(tokenRequestParameters!);
             var refreshRequest = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint) {
                 Content = refreshRequestContent
             };
@@ -261,7 +261,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
                 expiresIn = TimeSpan.FromSeconds(value);
             }
 
-            var tokens = CreateOAuthTokens(tokensResponse.TokenType, tokensResponse.AccessToken, expiresIn, tokensResponse.RefreshToken, clock);
+            var tokens = CreateOAuthTokens(tokensResponse.TokenType!, tokensResponse.AccessToken!, expiresIn, tokensResponse.RefreshToken, clock);
             return tokens;
         }
 
@@ -287,7 +287,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <returns>
         ///   A new <see cref="OAuthTokens"/> instance.
         /// </returns>
-        internal static OAuthTokens CreateOAuthTokens(string tokenType, string accessToken, TimeSpan? expiresIn, string refreshToken, ISystemClock clock) {
+        internal static OAuthTokens CreateOAuthTokens(string tokenType, string accessToken, TimeSpan? expiresIn, string? refreshToken, ISystemClock clock) {
             DateTimeOffset? utcExpiresAt = null;
 
             if (expiresIn != null) {

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStoreExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStoreExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
@@ -22,7 +21,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         ///   If the token store does not contain a valid access token, the return value will be 
         ///   <see langword="null"/>.
         /// </returns>
-        public static async Task<AuthenticationHeaderValue> GetAuthenticationHeaderAsync(this ITokenStore tokenStore) {
+        public static async Task<AuthenticationHeaderValue?> GetAuthenticationHeaderAsync(this ITokenStore tokenStore) {
             if (tokenStore == null) {
                 throw new ArgumentNullException(nameof(tokenStore));
             }

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/AccountTransactionsClient.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/AccountTransactionsClient.cs
@@ -66,7 +66,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Clients {
         /// </exception>
         public async Task<DebitUserResponse> DebitUserAsync(
             DebitUserRequest request,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -154,7 +154,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Clients {
         /// </exception>
         public async Task<RefundUserResponse> RefundUserAsync(
             RefundUserRequest request,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/OrganizationInfoClient.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/OrganizationInfoClient.cs
@@ -66,7 +66,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Clients {
         /// </exception>
         public async Task<IEnumerable<UserOrGroupPrincipal>> FindUsersAsync(
             UserOrGroupPrincipalSearchRequest request,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -118,7 +118,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Clients {
         /// </exception>
         public async Task<IEnumerable<UserOrGroupPrincipal>> FindGroupsAsync(
            UserOrGroupPrincipalSearchRequest request,
-           TContext context = default,
+           TContext? context = default,
            CancellationToken cancellationToken = default
         ) {
             if (request == null) {
@@ -160,7 +160,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Clients {
         ///   A task that will return the matching groups.
         /// </returns>
         public async Task<IEnumerable<UserOrGroupPrincipal>> GetGroupMembershipsAsync(
-           TContext context = default,
+           TContext? context = default,
            CancellationToken cancellationToken = default
         ) {
             var url = GetAbsoluteUrl("api/user-search/me/groups");

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/UserInfoClient.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/UserInfoClient.cs
@@ -52,7 +52,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Clients {
         ///   A task that will return the user information.
         /// </returns>
         public async Task<UserOrGroupPrincipal> GetUserInfoAsync(
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) {
             var url = GetAbsoluteUrl("api/user-search/me");

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/IndustrialAppStoreHttpClientExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/IndustrialAppStoreHttpClientExtensions.cs
@@ -60,7 +60,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client {
             int page = 1,
             int pageSize = 10,
             bool includeExternalResults = false,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) {
             if (client == null) {
@@ -123,7 +123,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client {
             int page = 1,
             int pageSize = 10,
             bool includeExternalResults = false,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) {
             if (client == null) {
@@ -175,7 +175,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client {
         public static async Task<DebitUserResponse> DebitUserAsync<TContext>(
             this AccountTransactionsClient<TContext> client,
             double amount,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) {
             if (client == null) {
@@ -224,7 +224,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client {
         public static async Task<RefundUserResponse> RefundUserAsync<TContext>(
             this AccountTransactionsClient<TContext> client,
             string transactionId,
-            TContext context = default,
+            TContext? context = default,
             CancellationToken cancellationToken = default
         ) {
             if (client == null) {

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Model/DebitUserResponse.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Model/DebitUserResponse.cs
@@ -9,7 +9,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Model {
         /// <summary>
         /// The transaction ID for the debit request.
         /// </summary>
-        public string TransactionId { get; set; }
+        public string? TransactionId { get; set; }
 
         /// <summary>
         /// A flag indicating if the transaction was successfully processed.
@@ -19,7 +19,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Model {
         /// <summary>
         /// The message associated with the transaction.
         /// </summary>
-        public string Message { get; set; }
+        public string? Message { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Model/PagedApiResponse.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Model/PagedApiResponse.cs
@@ -22,7 +22,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Model {
         /// <summary>
         /// The items.
         /// </summary>
-        public IEnumerable<T> Items { get; set; }
+        public IEnumerable<T> Items { get; set; } = default!;
 
     }
 }

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Model/RefundUserResponse.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Model/RefundUserResponse.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// The message associated with the refund response.
         /// </summary>
-        public string Message { get; set; }
+        public string? Message { get; set; }
 
     }
 

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Model/UserOrGroupPrincipal.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Model/UserOrGroupPrincipal.cs
@@ -9,27 +9,27 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Model {
         /// <summary>
         /// The principal name or unique identifier.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; set; } = default!;
 
         /// <summary>
         /// The principal's display name.
         /// </summary>
-        public string DisplayName { get; set; }
+        public string? DisplayName { get; set; }
 
         /// <summary>
         /// The principal's description.
         /// </summary>
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         /// <summary>
         /// The principal's picture URL.
         /// </summary>
-        public string PicUrl { get; set; }
+        public string? PicUrl { get; set; }
 
         /// <summary>
         /// The name of the organisation that the principal belongs to.
         /// </summary>
-        public string Org { get; set; }
+        public string? Org { get; set; }
 
         /// <summary>
         /// A flag that is <see langword="true"/> if the principal is not from the 

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Queries/RefundUserRequest.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Queries/RefundUserRequest.cs
@@ -12,7 +12,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Queries {
         /// </summary>
         [Required]
         [MaxLength(200)]
-        public string TransactionRef { get; set; }
+        public string TransactionRef { get; set; } = default!;
 
     }
 

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Queries/UserOrGroupPrincipalSearchRequest.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Queries/UserOrGroupPrincipalSearchRequest.cs
@@ -16,7 +16,7 @@ namespace IntelligentPlant.IndustrialAppStore.Client.Queries {
         /// The name filter.
         /// </summary>
         [MaxLength(100)]
-        public string Filter { get; set; }
+        public string Filter { get; set; } = default!;
 
         /// <summary>
         /// The page size.


### PR DESCRIPTION
- Enables nullable reference types
- Adds a `SessionIdGenerator` property to `IndustrialAppStoreAuthenticationOptions` to allows apps to customise how a session ID is generated for a login session