### PR TITLE
Add support for custom headers

### DIFF
--- a/docs/data-core-api-client/Getting-Started.md
+++ b/docs/data-core-api-client/Getting-Started.md
@@ -42,3 +42,8 @@ All Data Core API routes return an [RFC 7807 problem details](https://tools.ietf
 You can view the definition for the `ProblemDetails` type [here](https://github.com/intelligentplant/ProblemDetails.WebApi/blob/master/ProblemDetails.Core/ProblemDetails.cs).
 
 > Note that the `Detail` property on a problem details object is not guaranteed to be non-null. You should use `string.IsNullOrWhiteSpace(string?)` to determine if there is a value that you can display to an end user. 
+
+
+## Handling Retries
+
+We recommend using a library such as [Polly](https://github.com/App-vNext/Polly) to create HTTP clients capable of handling scenarios such as transient network interruptions and [API rate limits](https://github.com/App-vNext/Polly/issues/414). Note that, in the event of a `429/Too Many Requests` response being received from the server, the resulting `DataCoreHttpClientException` will have its `UtcRetryAfter` property set to the UTC time that the request can be attempted again at.

--- a/samples/CustomTokenStoreExample/CustomTokenStoreExample.csproj
+++ b/samples/CustomTokenStoreExample/CustomTokenStoreExample.csproj
@@ -20,11 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.161" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\IntelligentPlant.IndustrialAppStore.Authentication\IntelligentPlant.IndustrialAppStore.Authentication.csproj" />

--- a/samples/CustomTokenStoreExample/Startup.cs
+++ b/samples/CustomTokenStoreExample/Startup.cs
@@ -71,6 +71,7 @@ namespace ExampleMvcApplication {
             }
 
             services.AddControllersWithViews().AddNewtonsoftJson();
+            services.AddCustomHeaders();
         }
 
         
@@ -84,6 +85,8 @@ namespace ExampleMvcApplication {
         ///   The web host environment.
         /// </param>
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
+            app.UseCustomHeaders();
+
             if (env.IsDevelopment()) {
                 app.UseDeveloperExceptionPage();
             }

--- a/samples/CustomTokenStoreExample/appsettings.json
+++ b/samples/CustomTokenStoreExample/appsettings.json
@@ -9,5 +9,10 @@
   "AllowedHosts": "*",
   "IAS": {
     "ClientId": ""
+  },
+  "CustomHeaders": {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "deny",
+    "X-XSS-Protection": "1; mode=block"
   }
 }

--- a/samples/ExampleMvcApplication/ExampleMvcApplication.csproj
+++ b/samples/ExampleMvcApplication/ExampleMvcApplication.csproj
@@ -19,10 +19,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.161" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/ExampleMvcApplication/Startup.cs
+++ b/samples/ExampleMvcApplication/Startup.cs
@@ -43,6 +43,8 @@ namespace ExampleMvcApplication {
             }
 
             services.AddControllersWithViews().AddNewtonsoftJson();
+
+            services.AddCustomHeaders();
         }
 
         
@@ -56,6 +58,8 @@ namespace ExampleMvcApplication {
         ///   The web host environment.
         /// </param>
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
+            app.UseCustomHeaders();
+
             if (env.IsDevelopment()) {
                 app.UseDeveloperExceptionPage();
             }

--- a/samples/ExampleMvcApplication/appsettings.json
+++ b/samples/ExampleMvcApplication/appsettings.json
@@ -9,5 +9,10 @@
   "AllowedHosts": "*",
   "IAS": {
     "ClientId": ""
+  },
+  "CustomHeaders": {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "deny",
+    "X-XSS-Protection": "1; mode=block"
   }
 }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/CustomHeadersMiddleware.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/CustomHeadersMiddleware.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+
+namespace IntelligentPlant.IndustrialAppStore.Authentication {
+
+    /// <summary>
+    /// Middleware that adds headers from the <see cref="CustomHeadersProvider"/> service to every 
+    /// response.
+    /// </summary>
+    internal class CustomHeadersMiddleware {
+
+        /// <summary>
+        /// The next middleware delegate.
+        /// </summary>
+        private readonly RequestDelegate _next;
+
+        /// <summary>
+        /// The <see cref="CustomHeadersProvider"/> to use.
+        /// </summary>
+        private readonly CustomHeadersProvider _provider;
+
+
+        /// <summary>
+        /// Creates a new <see cref="CustomHeadersMiddleware"/> object.
+        /// </summary>
+        /// <param name="next">
+        ///   The next middleware delegate.
+        /// </param>
+        /// <param name="provider">
+        ///   The <see cref="CustomHeadersProvider"/> to use.
+        /// </param>
+        public CustomHeadersMiddleware(RequestDelegate next, CustomHeadersProvider provider) {
+            _next = next;
+            _provider = provider;
+        }
+
+
+        /// <summary>
+        /// Invokes the middleware.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="HttpContext"/> for the request.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="Task"/> that will process the request.
+        /// </returns>
+        public async Task InvokeAsync(HttpContext context) {
+            foreach (var item in _provider.GetHeaders()) {
+                context.Response.Headers.TryAdd(item.Key, item.Value);
+            }
+
+            await _next(context).ConfigureAwait(false);
+        }
+
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/CustomHeadersProvider.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/CustomHeadersProvider.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Primitives;
+
+namespace IntelligentPlant.IndustrialAppStore.Authentication {
+
+    /// <summary>
+    /// Service that provides custom headers to add to HTTP responses.
+    /// </summary>
+    internal class CustomHeadersProvider : IDisposable {
+
+        /// <summary>
+        /// <see cref="IConfiguration"/> section to load custom headers from.
+        /// </summary>
+        public const string ConfigurationSectionName = "CustomHeaders";
+
+        /// <summary>
+        /// Indicates if the services has been disposed.
+        /// </summary>
+        private bool _disposed;
+
+        /// <summary>
+        /// The <see cref="IConfiguration"/> to load headers from.
+        /// </summary>
+        private readonly IConfiguration _configuration;
+
+        /// <summary>
+        /// <see cref="ChangeToken"/> registration for monitoring <see cref="_configuration"/> for 
+        /// changes.
+        /// </summary>
+        private readonly IDisposable _ctReg;
+
+        /// <summary>
+        /// The custom headers.
+        /// </summary>
+        private Dictionary<string, string>? _headers;
+
+        /// <summary>
+        /// Lock for accessing <see cref="_headers"/>.
+        /// </summary>
+        private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
+
+
+        /// <summary>
+        /// Creates a new <see cref="CustomHeadersProvider"/> object.
+        /// </summary>
+        /// <param name="configuration">
+        ///   The <see cref="IConfiguration"/> to load custom headers from.
+        /// </param>
+        public CustomHeadersProvider(IConfiguration configuration) {
+            _configuration = configuration;
+            LoadHeaders();
+            _ctReg = ChangeToken.OnChange(() => _configuration.GetReloadToken(), () => LoadHeaders());
+        }
+
+
+        /// <summary>
+        /// Loads the custom headers from the <see cref="_configuration"/>.
+        /// </summary>
+        private void LoadHeaders() {
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var config = _configuration.GetSection(ConfigurationSectionName);
+            if (config == null) {
+                return;
+            }
+
+            foreach (var item in config.GetChildren()) {
+                headers[item.Key] = item.Value;
+            }
+
+            _lock.EnterWriteLock();
+            try {
+                _headers = headers;
+            }
+            finally {
+                _lock.ExitWriteLock();
+            }
+        }
+
+
+        /// <summary>
+        /// Gets the custom headers to add to an HTTP response.
+        /// </summary>
+        /// <returns>
+        ///   The custom headers.
+        /// </returns>
+        public IEnumerable<KeyValuePair<string, string>> GetHeaders() {
+            _lock.EnterReadLock();
+            try {
+                return _headers?.ToArray() ?? Array.Empty<KeyValuePair<string, string>>();
+            }
+            finally {
+                _lock.ExitReadLock();
+            }
+        }
+
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            if (_disposed) {
+                return;
+            }
+
+            _ctReg.Dispose();
+            _lock.Dispose();
+            _headers?.Clear();
+            _disposed = true;
+        }
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
@@ -266,47 +266,49 @@ namespace Microsoft.Extensions.DependencyInjection {
                     cookieOptions.LoginPath = iasOptions.LoginPath;
                 }
 
+                var cookieEvents = iasOptions.CookieAuthenticationEvents ?? new CookieAuthenticationEvents();
+
                 cookieOptions.Events = new CookieAuthenticationEvents() {
 #if NET6_0_OR_GREATER
                     OnCheckSlidingExpiration = async ctx => { 
-                        if (iasOptions.CookieAuthenticationEvents?.OnCheckSlidingExpiration != null) {
-                            await iasOptions.CookieAuthenticationEvents.OnCheckSlidingExpiration(ctx).ConfigureAwait(false);
+                        if (cookieEvents.OnCheckSlidingExpiration != null) {
+                            await cookieEvents.OnCheckSlidingExpiration(ctx).ConfigureAwait(false);
                         }
                     },
 #endif
                     OnRedirectToAccessDenied = async ctx => {
-                        if (iasOptions.CookieAuthenticationEvents?.OnRedirectToAccessDenied != null) {
-                            await iasOptions.CookieAuthenticationEvents.OnRedirectToAccessDenied(ctx).ConfigureAwait(false);
+                        if (cookieEvents.OnRedirectToAccessDenied != null) {
+                            await cookieEvents.OnRedirectToAccessDenied(ctx).ConfigureAwait(false);
                         }
                     },
                     OnRedirectToLogin = async ctx => {
-                        if (iasOptions.CookieAuthenticationEvents?.OnRedirectToLogin != null) {
-                            await iasOptions.CookieAuthenticationEvents.OnRedirectToLogin(ctx).ConfigureAwait(false);
+                        if (cookieEvents.OnRedirectToLogin != null) {
+                            await cookieEvents.OnRedirectToLogin(ctx).ConfigureAwait(false);
                         }
                     },
                     OnRedirectToLogout = async ctx => {
-                        if (iasOptions.CookieAuthenticationEvents?.OnRedirectToLogout != null) {
-                            await iasOptions.CookieAuthenticationEvents.OnRedirectToLogout(ctx).ConfigureAwait(false);
+                        if (cookieEvents.OnRedirectToLogout != null) {
+                            await cookieEvents.OnRedirectToLogout(ctx).ConfigureAwait(false);
                         }
                     },
                     OnRedirectToReturnUrl = async ctx => {
-                        if (iasOptions.CookieAuthenticationEvents?.OnRedirectToReturnUrl != null) {
-                            await iasOptions.CookieAuthenticationEvents.OnRedirectToReturnUrl(ctx).ConfigureAwait(false);
+                        if (cookieEvents.OnRedirectToReturnUrl != null) {
+                            await cookieEvents.OnRedirectToReturnUrl(ctx).ConfigureAwait(false);
                         }
                     },
                     OnSignedIn = async ctx => {
-                        if (iasOptions.CookieAuthenticationEvents?.OnSignedIn != null) {
-                            await iasOptions.CookieAuthenticationEvents.OnSignedIn(ctx).ConfigureAwait(false);
+                        if (cookieEvents.OnSignedIn != null) {
+                            await cookieEvents.OnSignedIn(ctx).ConfigureAwait(false);
                         }
                     },
                     OnSigningIn = async ctx => {
-                        if (iasOptions.CookieAuthenticationEvents?.OnSigningIn != null) {
-                            await iasOptions.CookieAuthenticationEvents.OnSigningIn(ctx).ConfigureAwait(false);
+                        if (cookieEvents.OnSigningIn != null) {
+                            await cookieEvents.OnSigningIn(ctx).ConfigureAwait(false);
                         }
                     },
                     OnSigningOut = async ctx => {
-                        if (iasOptions.CookieAuthenticationEvents?.OnSigningOut != null) {
-                            await iasOptions.CookieAuthenticationEvents.OnSigningOut(ctx).ConfigureAwait(false);
+                        if (cookieEvents.OnSigningOut != null) {
+                            await cookieEvents.OnSigningOut(ctx).ConfigureAwait(false);
                         }
                     },
                     OnValidatePrincipal = async ctx => {
@@ -321,8 +323,8 @@ namespace Microsoft.Extensions.DependencyInjection {
                             ctx.RejectPrincipal();
                         }
 
-                        if (iasOptions.CookieAuthenticationEvents?.OnValidatePrincipal != null) {
-                            await iasOptions.CookieAuthenticationEvents.OnValidatePrincipal(ctx).ConfigureAwait(false);
+                        if (cookieEvents.OnValidatePrincipal != null) {
+                            await cookieEvents.OnValidatePrincipal(ctx).ConfigureAwait(false);
                         }
                     }
                 };
@@ -415,7 +417,7 @@ namespace Microsoft.Extensions.DependencyInjection {
                             // Add session ID claim to identity. This can be used by custom
                             // ITokenStore implementations to distinguish between different login
                             // sessions from the same account.
-                            var sessionId = opts.SessionIdGenerator?.Invoke(context.Identity, context.HttpContext);
+                            var sessionId = opts.SessionIdGenerator?.Invoke(context.Identity!, context.HttpContext);
                             if (string.IsNullOrWhiteSpace(sessionId)) {
                                 sessionId = Guid.NewGuid().ToString("N");
                             }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreCustomHeadersExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreCustomHeadersExtensions.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+using IntelligentPlant.IndustrialAppStore.Authentication;
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Microsoft.Extensions.DependencyInjection {
+
+    /// <summary>
+    /// Extension methods for custom headers middleware.
+    /// </summary>
+    public static class IndustrialAppStoreCustomHeadersExtensions {
+
+        /// <summary>
+        /// Adds services for custom headers to the <see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">
+        ///   The <see cref="IServiceCollection"/>.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="IServiceCollection"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="services"/> is <see langword="null"/>.
+        /// </exception>
+        public static IServiceCollection AddCustomHeaders(this IServiceCollection services) {
+            if (services == null) { 
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            services.TryAddSingleton<CustomHeadersProvider>();
+
+            return services;
+        }
+
+
+        /// <summary>
+        /// Adds a middleware to the pipeline that will add custom headers to every response.
+        /// </summary>
+        /// <param name="app">
+        ///   The <see cref="IApplicationBuilder"/>.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="IApplicationBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="app"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///   Custom headers are configured via the <c>CustomHeaders</c> configuration section.
+        /// </remarks>
+        public static IApplicationBuilder UseCustomHeaders(this IApplicationBuilder app) {
+            if (app == null) {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            app.UseMiddleware<CustomHeadersMiddleware>();
+
+            return app;
+        }
+
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/ExampleMvcApplication.csproj.in
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/ExampleMvcApplication.csproj.in
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="IntelligentPlant.IndustrialAppStore.Authentication" Version="#{PACKAGE_VERSION}" />
     <!--#if (IsNet60) -->
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
     <!--#elseif (IsNet50) -->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.12" />
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.21" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
     <!--#endif -->
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.161" />
   </ItemGroup>
 
 </Project>

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/Startup.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/Startup.cs
@@ -50,6 +50,7 @@ namespace ExampleMvcApplication {
             }
 
             services.AddControllersWithViews().AddNewtonsoftJson();
+            services.AddCustomHeaders();
         }
 
         
@@ -63,6 +64,8 @@ namespace ExampleMvcApplication {
         ///   The web host environment.
         /// </param>
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
+            app.UseCustomHeaders();
+
             if (env.IsDevelopment()) {
                 app.UseDeveloperExceptionPage();
             }

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/appsettings.json
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/appsettings.json
@@ -9,5 +9,10 @@
   "AllowedHosts": "*",
   "IAS": {
     "ClientId": "<YOUR CLIENT ID>"
+  },
+  "CustomHeaders": {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "deny",
+    "X-XSS-Protection": "1; mode=block"
   }
 }


### PR DESCRIPTION
This PR adds support for middleware that will set custom headers on every HTTP response:

```
// Startup.cs
services.AddCustomHeaders();
...
app.UseCustomHeaders();
```

```
// appsettings.json
{
  "CustomHeaders": {
    "X-Content-Type-Options": "nosniff",
    "X-Frame-Options": "deny",
    "X-XSS-Protection": "1; mode=block"
  }
}
```