### PR TITLE
Remove .NET 5.0 targeting

### DIFF
--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IntelligentPlant.IndustrialAppStore.Authentication.csproj
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IntelligentPlant.IndustrialAppStore.Authentication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
     <Description>ASP.NET Core authentication handler for Intelligent Plant's Industrial App Store.</Description>
   </PropertyGroup>
 

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/IntelligentPlant.IndustrialAppStore.Templates.csproj
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/IntelligentPlant.IndustrialAppStore.Templates.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <DefaultNetCoreTargetFramework>netcoreapp3.1</DefaultNetCoreTargetFramework>
     <Title>Industrial App Store Templates</Title>
     <Authors>Intelligent Plant</Authors>
     <Description>Templates to use when creating an application for the Intelligent Plant Industrial App Store.</Description>

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/.template.config/template.json
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/.template.config/template.json
@@ -25,10 +25,6 @@
           "description": ".NET Core 3.1"
         },
         {
-          "choice": "net5.0",
-          "description": ".NET 5.0"
-        },
-        {
           "choice": "net6.0",
           "description": ".NET 6.0"
         }


### PR DESCRIPTION
Remove targeting for .NET 5.0 and target LTS versions only (i.e. .NET Core 3.1 and .NET 6.0)