### PR TITLE
Sticky device IDs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
     building via build.ps1 or build.sh. It is defined here to allow Visual Studio to build  
     the solution with the correct version number.
     -->
-    <Version>2.1.0</Version>
+    <Version>2.3.0-pre</Version>
   </PropertyGroup>
 
   <Choose>

--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 2,
-  "Minor": 2,
+  "Minor": 3,
   "Patch": 0,
-  "PreRelease": ""
+  "PreRelease": "pre"
 }

--- a/samples/CustomTokenStoreExample/AppBuilderUtils.cs
+++ b/samples/CustomTokenStoreExample/AppBuilderUtils.cs
@@ -35,16 +35,23 @@ namespace Microsoft.Extensions.DependencyInjection {
             services.AddCustomHeaders();
             services.AddContentSecurityPolicy();
 
-            services.AddIndustrialAppStoreAuthentication(options => {
+            services.AddIndustrialAppStoreAuthentication<EFTokenStore>(options => {
                 // Bind the settings from the app configuration to the Industrial App Store 
                 // authentication options.
                 configuration.GetSection("IAS").Bind(options);
 
-                // Specify the path to be our login page.
+                // Redirect to our login page when an authentication challenge is issued.
                 options.LoginPath = new PathString("/Account/Login");
 
-                // The IndustrialAppStoreAuthenticationOptions.ConfigureHttpClient property can be
-                // used to customise the HttpClient that is used for Data Core API calls e.g. 
+                // The UseCookieSessionIdGenerator extension method configures the SessionIdGenerator
+                // property to store a persistent device ID cookie in the calling user agent, so
+                // that logins from the same browser will always use the same session ID. If
+                // SessionIdGenerator is not configured, a new session ID will be generated for
+                // every login.
+                options.UseCookieSessionIdGenerator();
+
+                // The ConfigureHttpClient property can be used to customise the HttpClient that is
+                // used for Data Core API calls e.g. 
                 //options.ConfigureHttpClient = builder => builder.AddHttpMessageHandler<MyCustomHandler>();
             });
 

--- a/samples/CustomTokenStoreExample/Models/UserTokens.cs
+++ b/samples/CustomTokenStoreExample/Models/UserTokens.cs
@@ -21,7 +21,7 @@ namespace ExampleMvcApplication.Models {
 
         public DateTimeOffset? ExpiryTime { get; set; }
 
-        public string RefreshToken { get; set; }
+        public string? RefreshToken { get; set; }
 
     }
 }

--- a/samples/ExampleMvcApplication/AppBuilderUtils.cs
+++ b/samples/ExampleMvcApplication/AppBuilderUtils.cs
@@ -23,11 +23,18 @@
                 // authentication options.
                 configuration.GetSection("IAS").Bind(options);
 
-                // Specify the path to be our login page.
+                // Redirect to our login page when an authentication challenge is issued.
                 options.LoginPath = new PathString("/Account/Login");
 
-                // The IndustrialAppStoreAuthenticationOptions.ConfigureHttpClient property can be
-                // used to customise the HttpClient that is used for Data Core API calls e.g. 
+                // The UseCookieSessionIdGenerator extension method configures the SessionIdGenerator
+                // property to store a persistent device ID cookie in the calling user agent, so
+                // that logins from the same browser will always use the same session ID. If
+                // SessionIdGenerator is not configured, a new session ID will be generated for
+                // every login.
+                //options.UseCookieSessionIdGenerator();
+
+                // The ConfigureHttpClient property can be used to customise the HttpClient that is
+                // used for Data Core API calls e.g. 
                 //options.ConfigureHttpClient = builder => builder.AddHttpMessageHandler<MyCustomHandler>();
             });
 

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
@@ -11,6 +11,7 @@ using IntelligentPlant.IndustrialAppStore.Client;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 
 using HttpHandlerType = System.Net.Http.SocketsHttpHandler;
@@ -510,6 +511,101 @@ namespace Microsoft.Extensions.DependencyInjection {
             else {
                 await tokenStore.InitAsync(userId, sessionId).ConfigureAwait(false);
             }
+        }
+
+
+        /// <summary>
+        /// Gets or creates the session ID for the specified <see cref="HttpContext"/>.
+        /// </summary>
+        /// <param name="context">
+        ///   The <see cref="HttpContext"/>.
+        /// </param>
+        /// <param name="clientId">
+        ///   The Industrial App Store client ID for the app.
+        /// </param>
+        /// <param name="configureCookie">
+        ///   A callback that can be used to customise the <see cref="CookieOptions"/> for the 
+        ///   device ID cookie.
+        /// </param>
+        /// <returns>
+        ///   A session ID for the calling browser.
+        /// </returns>
+        /// <remarks>
+        ///   The session ID is a GUID, which is encrypted using <see cref="IDataProtector"/> and 
+        ///   saved in a persistent cookie in the browser. This allows the same session identifier 
+        ///   to be re-used for the same browser/device combination across login sessions.
+        /// </remarks>
+        private static string GetOrCreateSessionId(HttpContext context, string clientId, Action<CookieOptions>? configureCookie) {
+            const string cookieName = ".IndustrialAppStore.App.DeviceId";
+
+            var provider = context.RequestServices.GetRequiredService<IDataProtectionProvider>();
+            var dataProtector = provider.CreateProtector("IndustrialAppStore.Authentication", "deviceId", clientId);
+
+            string sessionId;
+
+            void CreateSessionId() {
+                sessionId = Guid.NewGuid().ToString("N");
+
+                var cookieOptions = new CookieOptions() {
+                    HttpOnly = true,
+                    SameSite = SameSiteMode.Lax,
+                    Secure = context.Request.IsHttps,
+                    Expires = new DateTimeOffset(2038, 1, 1, 0, 0, 0, TimeSpan.Zero)
+                };
+
+                configureCookie?.Invoke(cookieOptions);
+
+                context.Response.Cookies.Append(cookieName, dataProtector.Protect(sessionId), cookieOptions);
+            }
+
+            if (context.Request.Cookies.TryGetValue(cookieName, out var deviceId)) {
+                try {
+                    sessionId = dataProtector.Unprotect(deviceId!);
+                }
+                catch {
+                    CreateSessionId();
+                }
+            }
+            else {
+                CreateSessionId();
+            }
+
+            return sessionId;
+        }
+
+
+        /// <summary>
+        /// Updates the <see cref="IndustrialAppStoreAuthenticationOptions.SessionIdGenerator"/> 
+        /// to derive a session ID from a device ID cookie in a user's browser, so that the same 
+        /// session ID can be used every time the user logs in using that browser.
+        /// </summary>
+        /// <param name="options">
+        ///   The <see cref="IndustrialAppStoreAuthenticationOptions"/>.
+        /// </param>
+        /// <param name="configure">
+        ///   An optional callback that can be used to configure the properties of the device ID 
+        ///   cookie when it is set.
+        /// </param>
+        /// <returns>
+        ///   The <see cref="IndustrialAppStoreAuthenticationOptions"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="options"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///   Where an device ID cookie does not already exist, a random, globally-unique value 
+        ///   will be generated and used. That is, the identifier is not derived from any 
+        ///   properties of the calling user agent. The cookie value is always encrypted using 
+        ///   ASP.NET Core's <see cref="IDataProtector"/> service.
+        /// </remarks>
+        public static IndustrialAppStoreAuthenticationOptions UseCookieSessionIdGenerator(this IndustrialAppStoreAuthenticationOptions options, Action<CookieOptions>? configure = null) {
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            options.SessionIdGenerator = (identity, context) => GetOrCreateSessionId(context, options.ClientId, configure);
+
+            return options;
         }
 
     }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptions.cs
@@ -132,12 +132,20 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// </para>
         /// 
         /// <para>
+        ///   The <seealso cref="IndustrialAppStoreAuthenticationExtensions.UseCookieSessionIdGenerator"/> 
+        ///   extension method can be used to assign a value to <see cref="SessionIdGenerator"/> 
+        ///   that will store an identifier for the browser in a persistent cookie and re-use it 
+        ///   across different login sessions.
+        /// </para>
+        /// 
+        /// <para>
         ///   If <see cref="SessionIdGenerator"/> is <see langword="null"/> or returns a 
         ///   <see langword="null"/> or white space value, a unique identifier will be generated 
         ///   for the session.
         /// </para>
         /// 
         /// </remarks>
+        /// <seealso cref="IndustrialAppStoreAuthenticationExtensions.UseCookieSessionIdGenerator"/>
         public Func<ClaimsIdentity, HttpContext, string>? SessionIdGenerator { get; set; }
 
     }

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/AppBuilderUtils.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/AppBuilderUtils.cs
@@ -36,11 +36,18 @@ namespace Microsoft.Extensions.DependencyInjection {
                 // authentication options.
                 configuration.GetSection("IAS").Bind(options);
 
-                // Specify the path to be our login page.
+                // Redirect to our login page when an authentication challenge is issued.
                 options.LoginPath = new PathString("/Account/Login");
 
-                // The IndustrialAppStoreAuthenticationOptions.ConfigureHttpClient property can be
-                // used to customise the HttpClient that is used for Data Core API calls e.g. 
+                // The UseCookieSessionIdGenerator extension method configures the SessionIdGenerator
+                // property to store a persistent device ID cookie in the calling user agent, so
+                // that logins from the same browser will always use the same session ID. If
+                // SessionIdGenerator is not configured, a new session ID will be generated for
+                // every login.
+                //options.UseCookieSessionIdGenerator();
+
+                // The ConfigureHttpClient property can be used to customise the HttpClient that is
+                // used for Data Core API calls e.g. 
                 //options.ConfigureHttpClient = builder => builder.AddHttpMessageHandler<MyCustomHandler>();
             });
 


### PR DESCRIPTION
This PR adds an extension method for `IndustrialAppStoreAuthenticationOptions` that allows a "sticky" device ID for a browser to be generated and stored in a persistent cookie.

This provides a simple way of ensuring that logins from the same browser use the same session ID, which is useful when a custom `ITokenStore` implementation is used to persist access and refresh tokens in e.g. a SQL database. 