### PR TITLE
Update Cake extensions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.0.0",
+      "version": "2.2.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/build.cake
+++ b/build.cake
@@ -15,7 +15,7 @@ const string VersionFile = "./build/version.json";
 // --target=<TARGET>
 //   The Cake target to run. 
 //     Default: Test
-//     Possible Values: Clean, Restore, Build, Test, Pack
+//     Possible Values: Clean, Restore, Build, Test, Pack, BillOfMaterials
 //
 // --configuration=<CONFIGURATION>
 //   The MSBuild configuration to use. 
@@ -48,10 +48,20 @@ const string VersionFile = "./build/version.json";
 //   Specifies an additional property to pass to MSBuild during Build and Pack targets. The value
 //   must be specified using a '<NAME>=<VALUE>' format e.g. --property="NoWarn=CS1591". This 
 //   argument can be specified multiple times.
+//
+// --github-username=<USERNAME>
+//   Specifies the GitHub username to use when making authenticated API calls to GitHub while 
+//   running the BillOfMaterials target. You must specify the --github-token argument as well when 
+//   specifying this argument.
+//
+// --github-token=<PERSONAL ACCESS TOKEN>
+//   Specifies the GitHub personal access token to use when making authenticated API calls to 
+//   GitHub while running the BillOfMaterials target. You must specify the --github-username 
+//   argument as well when specifying this argument.
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=1.1.0
+#load nuget:?package=Jaahas.Cake.Extensions&version=1.5.0
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);

--- a/samples/CustomTokenStoreExample/CustomTokenStoreExample.csproj
+++ b/samples/CustomTokenStoreExample/CustomTokenStoreExample.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.161" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
   </ItemGroup>
   
   <ItemGroup>

--- a/samples/ExampleMvcApplication/ExampleMvcApplication.csproj
+++ b/samples/ExampleMvcApplication/ExampleMvcApplication.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.2" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.161" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Update Cake extensions to allow GitHub credentials to be passed to CycloneDX when generating a Bill of Materials