### PR TITLE
Template cleanup

### DIFF
--- a/build/Dependencies.props
+++ b/build/Dependencies.props
@@ -4,7 +4,7 @@
 
   <!-- Dev/Test/Benchmark Packages -->
   <PropertyGroup>
-    <MicrosoftCodeAnalysisNetAnalyzersVersion>6.0.0</MicrosoftCodeAnalysisNetAnalyzersVersion>
+    <MicrosoftCodeAnalysisNetAnalyzersVersion>7.0.0</MicrosoftCodeAnalysisNetAnalyzersVersion>
     <MicrosoftSourceLinkGitHubVersion>1.1.1</MicrosoftSourceLinkGitHubVersion>
   </PropertyGroup>
   

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/.template.config/template.json
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/.template.config/template.json
@@ -23,10 +23,6 @@
         {
           "choice": "net6.0",
           "description": ".NET 6.0"
-        },
-        {
-          "choice": "netcoreapp3.1",
-          "description": ".NET Core 3.1"
         }
       ],
       "defaultValue": "net6.0",

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/templates/iasmvc/README.md
@@ -57,7 +57,7 @@ Next, you must update the `appsettings.json` file (in the same folder as this RE
 
 ### Client Secrets
 
-If you generated a secret key for your app, use the [ASP.NET Core Secret Manager](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets) to save the secret using the following command:
+If you generated a secret key for your app, use the [ASP.NET Core Secret Manager](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets) to save the secret by running the following command from the project folder:
 
     dotnet user-secrets set "IAS:ClientSecret" "<YOUR CLIENT SECRET>"
 


### PR DESCRIPTION
This PR removes .NET Core 3.1 as an option when creating an app from the template since it is now out of support.

It also fixes #61 by specifying where to run `dotnet user-secrets` commands from.