### PR TITLE
HTTP factory improvements

### DIFF
--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/Http/TokenStoreHttpFactory.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/Http/TokenStoreHttpFactory.cs
@@ -42,7 +42,7 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication.Http {
 
 
         /// <inheritdoc/>
-        public override HttpMessageHandler CreateHandler() {
+        protected override HttpMessageHandler CreateHandler() {
             var httpHandler = base.CreateHandler();
 
             if (!_options.Value.UseExternalAuthentication) {

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IIndustrialAppStoreHttpFactory.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IIndustrialAppStoreHttpFactory.cs
@@ -7,10 +7,19 @@ namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
     /// use with <see cref="Client.IndustrialAppStoreHttpClient"/> instances.
     /// </summary>
     /// <remarks>
+    /// 
+    /// <para>
     ///   <see cref="IIndustrialAppStoreHttpFactory"/> allows the HTTP request pipeline for a 
     ///   client to be customised in ways that may not be possible when using <see cref="IHttpMessageHandlerFactory"/> 
     ///   directly, such as adding custom scope-specific authentication headers to outgoing 
     ///   requests.
+    /// </para>
+    /// 
+    /// <para>
+    ///   Implementations should inherit from <see cref="IndustrialAppStoreHttpFactory"/> instead 
+    ///   of implementing <see cref="IIndustrialAppStoreHttpFactory"/> directly.
+    /// </para>
+    /// 
     /// </remarks>
     public interface IIndustrialAppStoreHttpFactory {
 
@@ -21,6 +30,14 @@ namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
         ///   The HTTP message handler.
         /// </returns>
         HttpMessageHandler CreateHandler();
+
+        /// <summary>
+        /// Creates a new <see cref="HttpClient"/> instance.
+        /// </summary>
+        /// <returns>
+        ///   The <see cref="HttpClient"/> instance.
+        /// </returns>
+        HttpClient CreateClient();
 
     }
 

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreHttpFactory.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreHttpFactory.cs
@@ -31,8 +31,37 @@ namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
         }
 
 
+        /// <summary>
+        /// Creates a new HTTP message handler.
+        /// </summary>
+        /// <returns>
+        ///   The HTTP message handler.
+        /// </returns>
+        protected virtual HttpMessageHandler CreateHandler() => _httpMessageHandlerFactory.CreateHandler(nameof(IndustrialAppStoreHttpClient));
+
+
+        /// <summary>
+        /// Creates a new <see cref="HttpClient"/> instance.
+        /// </summary>
+        /// <returns>
+        ///   The <see cref="HttpClient"/> instance.
+        /// </returns>
+        protected virtual HttpClient CreateClient() {
+            var http = new HttpClient(CreateHandler(), false);
+#if NET8_0_OR_GREATER
+            http.DefaultRequestVersion = System.Net.HttpVersion.Version11;
+            http.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+#endif
+            return http;
+        }
+
+
         /// <inheritdoc/>
-        public virtual HttpMessageHandler CreateHandler() => _httpMessageHandlerFactory.CreateHandler(nameof(IndustrialAppStoreHttpClient));
+        HttpMessageHandler IIndustrialAppStoreHttpFactory.CreateHandler() => CreateHandler();
+
+
+        /// <inheritdoc/>
+        HttpClient IIndustrialAppStoreHttpFactory.CreateClient() => CreateClient();
 
     }
 }


### PR DESCRIPTION
This PR extends `IIndustrialAppStoreHttpFactory` so that the factory can also be used to directly create `HttpClient` instances. This allows implementers to extend the `IndustrialAppStoreHttpFactory` implementation if they need to customise the final `HttpClient` in any way, since this cannot be via the standard HTTP client builder since the default IAS factories use `IHttpMessageHandlerFactory` instead of `IHttpClientFactory` under the hood.