### PR TITLE
Clarify namespaces for client types

### DIFF
--- a/docs/migration-guides/v2-v3.md
+++ b/docs/migration-guides/v2-v3.md
@@ -36,7 +36,11 @@ builder.Services
 
 # Changes to API Client Types
 
-You should use the `IndustrialAppStoreHttpClient` class to query the Industrial App Store APIs and the `DataCoreHttpClient` class to query an on-premises Data Core instance. Generic versions of these classes and other derived types (such as `BackchannelIndustrialAppStoreHttpClient`) have been removed.
+You should use the `IntelligentPlant.IndustrialAppStore.Client.IndustrialAppStoreHttpClient` class to query the Industrial App Store APIs and the `IntelligentPlant.DataCore.Client.DataCoreHttpClient` class to query an on-premises Data Core instance. 
+
+Generic versions of these classes and other derived types (such as `BackchannelIndustrialAppStoreHttpClient`) have been removed.
+
+Note that the namespaces for the client types may be different to those used in applications using the v2 client tools and you may need to update your `using` directives accordingly.
 
 
 ## Removal of Context Parameter from API Methods


### PR DESCRIPTION
This PR updates the v2-v3 migration guide to highlight that the namespaces for API client types used in an app may have changed after updating to the v3 version of the client tools.