### PR TITLE
Allow custom scopes to be requested in device flow

### DIFF
--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManager.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManager.cs
@@ -302,6 +302,7 @@ namespace IntelligentPlant.IndustrialAppStore.CommandLine {
             var tokens = await httpClient.AuthenticateWithDeviceCodeAsync(new DeviceLoginOptions() {
                 ClientId = _options.ClientId,
                 ClientSecret = _options.ClientSecret,
+                Scopes = _options.Scopes,
                 DeviceAuthorizationEndpoint = GetDeviceAuthorizationEndpoint(),
                 TokenEndpoint = GetTokenEndpoint(),
                 OnRequestCreated = callback

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManagerOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManagerOptions.cs
@@ -37,6 +37,12 @@ namespace IntelligentPlant.IndustrialAppStore.CommandLine {
         public string? ClientSecret { get; set; }
 
         /// <summary>
+        /// Additional scopes to request when authenticating the user, in addition to the default 
+        /// scopes registered for the app.
+        /// </summary>
+        public string[]? Scopes { get; set; }
+
+        /// <summary>
         /// The path to the folder where tokens will be stored.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
This PR allows additonal scopes to be requested when using the command-line helper library.