### PR TITLE
Clean up namespace imports

### DIFF
--- a/samples/CustomTokenStoreExample/Controllers/AccountController.cs
+++ b/samples/CustomTokenStoreExample/Controllers/AccountController.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-
-using ExampleMvcApplication.Models;
+﻿using ExampleMvcApplication.Models;
 
 using IntelligentPlant.IndustrialAppStore.Authentication;
 

--- a/samples/CustomTokenStoreExample/Models/IndexViewModel.cs
+++ b/samples/CustomTokenStoreExample/Models/IndexViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Microsoft.AspNetCore.Mvc.Rendering;
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace ExampleMvcApplication.Models {
     public class IndexViewModel {

--- a/samples/CustomTokenStoreExample/Models/TagListViewModel.cs
+++ b/samples/CustomTokenStoreExample/Models/TagListViewModel.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using IntelligentPlant.DataCore.Client.Model;
+﻿using IntelligentPlant.DataCore.Client.Model;
 
 namespace ExampleMvcApplication.Models {
     public class TagListViewModel {

--- a/samples/CustomTokenStoreExample/Models/UserTokens.cs
+++ b/samples/CustomTokenStoreExample/Models/UserTokens.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ExampleMvcApplication.Models {

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/AssetModelClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/AssetModelClient.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 
 using IntelligentPlant.DataCore.Client.Model;
 using IntelligentPlant.DataCore.Client.Model.AssetModel;

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/ClientBase.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/ClientBase.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Net.Http;
-
-namespace IntelligentPlant.DataCore.Client.Clients {
+﻿namespace IntelligentPlant.DataCore.Client.Clients {
 
     /// <summary>
     /// Base class for <see cref="DataCoreHttpClient"/> sub-client types.

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/CustomFunctionsClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/CustomFunctionsClient.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 
 using IntelligentPlant.DataCore.Client.Model.Queries;
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/DataSourcesClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/DataSourcesClient.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Net.Http;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Net.Http.Formatting;
-using System.Threading;
-using System.Threading.Tasks;
 
 using IntelligentPlant.DataCore.Client.Model;
 using IntelligentPlant.DataCore.Client.Model.Queries;

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/EventSinksClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/EventSinksClient.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 
 using IntelligentPlant.DataCore.Client.Model;
 using IntelligentPlant.DataCore.Client.Model.Queries;

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/EventSourcesClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/EventSourcesClient.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 
 using IntelligentPlant.DataCore.Client.Model;
 using IntelligentPlant.DataCore.Client.Model.Queries;

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/InfoClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/InfoClient.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace IntelligentPlant.DataCore.Client.Clients {
+﻿namespace IntelligentPlant.DataCore.Client.Clients {
 
     /// <summary>
     /// Provides information and diagnostic queries for Data Core.

--- a/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClient.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Net.Http;
-using System.Net.Http.Formatting;
+﻿using System.Net.Http.Formatting;
 
 using IntelligentPlant.DataCore.Client.Clients;
 

--- a/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientException.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientException.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Globalization;
-using System.Linq;
+﻿using System.Collections.ObjectModel;
 using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
 
 namespace IntelligentPlant.DataCore.Client {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientExtensions.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientExtensions.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-using IntelligentPlant.DataCore.Client.Clients;
+﻿using IntelligentPlant.DataCore.Client.Clients;
 using IntelligentPlant.DataCore.Client.Model;
 using IntelligentPlant.DataCore.Client.Model.Scripting;
 using IntelligentPlant.DataCore.Client.Queries;

--- a/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientOptions.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClientOptions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/HttpResponseMessageExtensions.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/HttpResponseMessageExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading.Tasks;
-
-namespace IntelligentPlant.DataCore.Client {
+﻿namespace IntelligentPlant.DataCore.Client {
 
     /// <summary>
     /// Extensions for <see cref="HttpResponseMessage"/>.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Annotation.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Annotation.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AnnotationCollection.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AnnotationCollection.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes a collection of annotations associated with a tag.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AnnotationIdentifier.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AnnotationIdentifier.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelElement.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelElement.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
+﻿namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
 
     /// <summary>
     /// Describes an element (node) in an asset model hierarchy.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelElementTemplate.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/AssetModel/AssetModelElementTemplate.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
+﻿namespace IntelligentPlant.DataCore.Client.Model.AssetModel {
 
     /// <summary>
     /// Describes an element template in an asset model.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentConfiguration.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentConfiguration.cs
@@ -1,7 +1,5 @@
-﻿using System.Collections.Generic;
+﻿namespace IntelligentPlant.DataCore.Client.Model {
 
-namespace IntelligentPlant.DataCore.Client.Model {
-    
     /// <summary>
     /// Describes the configuration of a Data Core component.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentHealth.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentHealth.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentHealthProperty.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentHealthProperty.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentInfo.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentName.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentName.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentRoles.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentRoles.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes the roles a user has on a datasource.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentStatus.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ComponentStatus.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace IntelligentPlant.DataCore.Client.Model {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/DataSourceDriverFeatures.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/DataSourceDriverFeatures.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/EventMessage.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/EventMessage.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/EventRouteEntry.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/EventRouteEntry.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes an entry in a route taken for an item such as an <see cref="EventMessage"/> from its source to its current location.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ExpressionTagReference.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ExpressionTagReference.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
 
     /// <summary>
     /// Describes a tag reference in an expression.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/ExpressionValidationResult.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/ExpressionValidationResult.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
 
     /// <summary>
     /// Describes the validation result for an expression.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/GetAnnotationsRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/GetAnnotationsRequest.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/HistoricalTagValues.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/HistoricalTagValues.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace IntelligentPlant.DataCore.Client.Model
-{
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes the results of a historical data query for a single tag.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/IEventMessage.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/IEventMessage.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
 
     /// <summary>
     /// Interface that describes a Data Core event message.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/IEventRouteEntry.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/IEventRouteEntry.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
 
     /// <summary>
     /// Describes an entry in a route taken for an item such as an <see cref="IEventMessage"/> from its source to its current location.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/IIntermediateTagValues.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/IIntermediateTagValues.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
 
     /// <summary>
     /// Describes a data query result for a single tag returned by Data Core.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/IntermediateTagValues.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/IntermediateTagValues.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 #nullable disable

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/LogMessage.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/LogMessage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Globalization;
+﻿using System.Globalization;
 
 using Newtonsoft.Json;
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/NamedValue.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/NamedValue.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
 
     /// <summary>
     /// Describes a named key-value pair.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Person.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Person.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
 
 namespace IntelligentPlant.DataCore.Client.Model {

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/RealTimeDataSubscriptionInfo.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/RealTimeDataSubscriptionInfo.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes a Data Core real-time subscription.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagArchiveSettings.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagArchiveSettings.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model.Scripting {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagMetadata.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagMetadata.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace IntelligentPlant.DataCore.Client.Model.Scripting {
+﻿namespace IntelligentPlant.DataCore.Client.Model.Scripting {
 
     /// <summary>
     /// Describes metadata about a script tag.

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagSettings.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagSettings.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model.Scripting {

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagSettingsBase.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagSettingsBase.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using System.Text.RegularExpressions;
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagValueScriptSettings.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/ScriptTagValueScriptSettings.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Globalization;
-using System.Linq;
 
 using IntelligentPlant.Relativity;
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplate.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplate.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplateParameterDefinition.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplateParameterDefinition.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
     /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplateWithParameterDefinitions.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/ScriptTemplateWithParameterDefinitions.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
+﻿namespace IntelligentPlant.DataCore.Client.Model.Scripting.Templates {
 
     /// <summary>
     /// An extended version of <see cref="ScriptTemplate"/> that includes details about the parameters 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/TemplatedScriptTagSettings.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/Scripting/Templates/TemplatedScriptTagSettings.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchFilter.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchFilter.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 
 namespace IntelligentPlant.DataCore.Client.Model {

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchResult.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchResult.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchResultCollection.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchResultCollection.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes a set of tags that were retrieved from a data source as part of a composite tag search.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValue.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValue.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Text;
+﻿using System.Text;
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueDictionary.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueDictionary.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Dictionary that maps from tag name to tag values.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscriptionResult.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscriptionResult.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes the result of a subscription request for real-time tag values.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscriptionResultItem.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueSubscriptionResultItem.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes the subscription result for a single tag in a <see cref="TagValueSubscriptionResult"/>.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdate.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdate.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes a tag value that will be written to a data source.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdateCollection.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdateCollection.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdateResponse.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValueUpdateResponse.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace IntelligentPlant.DataCore.Client.Model {
+﻿namespace IntelligentPlant.DataCore.Client.Model {
     /// <summary>
     /// Describes the response sent by Data Core after writing tag values to a data source.
     /// </summary>

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagValuesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagValuesRequest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 #nullable disable
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/CreateTemplatedScriptTagRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/CreateTemplatedScriptTagRequest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 using IntelligentPlant.DataCore.Client.Model.Scripting.Templates;
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/CustomFunctionRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/CustomFunctionRequest.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 
 namespace IntelligentPlant.DataCore.Client.Model.Queries {

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/GetTagsRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/GetTagsRequest.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Queries {
     public class GetTagsRequest : DataSourceRequest, IValidatableObject {

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadAnnotationsRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadAnnotationsRequest.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 using Newtonsoft.Json;
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadProcessedTagValuesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadProcessedTagValuesRequest.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Queries {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadTagValuesAtTimesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadTagValuesAtTimesRequest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Queries {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadTagValuesForTimeRangeRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadTagValuesForTimeRangeRequest.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Queries {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadTagValuesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/ReadTagValuesRequest.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace IntelligentPlant.DataCore.Client.Queries {
 

--- a/src/IntelligentPlant.DataCore.HttpClient/Queries/WriteTagValuesRequest.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Queries/WriteTagValuesRequest.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
+﻿using System.ComponentModel.DataAnnotations;
 
 using IntelligentPlant.DataCore.Client.Model;
 

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/AuthenticationPropertiesTokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/AuthenticationPropertiesTokenStore.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Net.Http;
-using System.Threading.Tasks;
+﻿using System.Globalization;
 
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/Http/TokenStoreAuthenticationHandler.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/Http/TokenStoreAuthenticationHandler.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace IntelligentPlant.IndustrialAppStore.Authentication.Http {
+﻿namespace IntelligentPlant.IndustrialAppStore.Authentication.Http {
 
     /// <summary>
     /// <see cref="DelegatingHandler"/> that authenticates outgoing requests using an Industrial 

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/Http/TokenStoreHttpFactory.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/Http/TokenStoreHttpFactory.cs
@@ -1,6 +1,4 @@
-﻿using System.Net.Http;
-
-using IntelligentPlant.IndustrialAppStore.DependencyInjection;
+﻿using IntelligentPlant.IndustrialAppStore.DependencyInjection;
 
 using Microsoft.Extensions.Options;
 

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/ITokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/ITokenStore.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
-
-namespace IntelligentPlant.IndustrialAppStore.Authentication {
+﻿namespace IntelligentPlant.IndustrialAppStore.Authentication {
 
     /// <summary>
     /// <see cref="ITokenStore"/> is used to retrieve the Industrial App Store access token for an 

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Net.Http;
-
-using IntelligentPlant.IndustrialAppStore.Authentication;
+﻿using IntelligentPlant.IndustrialAppStore.Authentication;
 using IntelligentPlant.IndustrialAppStore.Authentication.Http;
 using IntelligentPlant.IndustrialAppStore.Authentication.Options;
 using IntelligentPlant.IndustrialAppStore.Client;

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptionsExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptionsExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Microsoft.AspNetCore.DataProtection;
+﻿using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/OAuthTokens.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/OAuthTokens.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace IntelligentPlant.IndustrialAppStore.Authentication {
+﻿namespace IntelligentPlant.IndustrialAppStore.Authentication {
 
     /// <summary>
     /// Describes OAuth tokens associated with an Industrial App Store authentication session.

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/Options/PostConfigureAuthenticationOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/Options/PostConfigureAuthenticationOptions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Microsoft.AspNetCore.Authentication;
+﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/Options/PostConfigureIasClientOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/Options/PostConfigureIasClientOptions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using IntelligentPlant.IndustrialAppStore.Client;
+﻿using IntelligentPlant.IndustrialAppStore.Client;
 
 using Microsoft.Extensions.Options;
 

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/Options/PostConfigureIasCookieAuthenticationOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/Options/PostConfigureIasCookieAuthenticationOptions.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-using Microsoft.AspNetCore.Authentication;
+﻿using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/Options/PostConfigureIasOAuthOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/Options/PostConfigureIasOAuthOptions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net.Http.Headers;
-using System.Net.Http;
+﻿using System.Net.Http.Headers;
 using System.Security.Claims;
 
 using Microsoft.AspNetCore.Authentication;

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStore.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Net.Http;
+﻿using System.Globalization;
 using System.Net.Http.Headers;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStoreExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStoreExtensions.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
 using System.Security.Claims;
-using System.Threading.Tasks;
 
 using Microsoft.AspNetCore.Authentication;
 

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/Http/AuthenticationHandler.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/Http/AuthenticationHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Net.Http;
-using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
 
 namespace IntelligentPlant.IndustrialAppStore.CommandLine.Http {
 

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/Http/HttpClientExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/Http/HttpClientExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Net.Http;
 using System.Net.Http.Json;
 
 using IntelligentPlant.IndustrialAppStore.CommandLine.OAuth;

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManager.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManager.cs
@@ -1,5 +1,4 @@
-﻿using System.Net.Http;
-using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text;

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/DefaultIndustrialAppStoreHttpFactory.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/DefaultIndustrialAppStoreHttpFactory.cs
@@ -1,6 +1,4 @@
-﻿using System.Net.Http;
-
-namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
+﻿namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
 
     /// <summary>
     /// Default implementation of <see cref="IIndustrialAppStoreHttpFactory"/>.

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IIndustrialAppStoreHttpFactory.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IIndustrialAppStoreHttpFactory.cs
@@ -1,6 +1,4 @@
-﻿using System.Net.Http;
-
-namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
+﻿namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
 
     /// <summary>
     /// <see cref="IIndustrialAppStoreHttpFactory"/> is responsible for creating HTTP handlers for 

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreExtensions.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Net.Http;
-
-using IntelligentPlant.DataCore.Client;
+﻿using IntelligentPlant.DataCore.Client;
 using IntelligentPlant.IndustrialAppStore.Client;
 using IntelligentPlant.IndustrialAppStore.DependencyInjection;
 using IntelligentPlant.IndustrialAppStore.DependencyInjection.Internal;

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreHttpFactory.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreHttpFactory.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Net.Http;
-
-using IntelligentPlant.IndustrialAppStore.Client;
+﻿using IntelligentPlant.IndustrialAppStore.Client;
 
 namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
 

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/AccountTransactionsClient.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/AccountTransactionsClient.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.Globalization;
-using System.Net.Http;
-using System.Net.Http.Formatting;
-using System.Threading;
-using System.Threading.Tasks;
 
 using IntelligentPlant.DataCore.Client;
 using IntelligentPlant.IndustrialAppStore.Client.Model;

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/IasClientBase.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/IasClientBase.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Net.Http;
-
-using IntelligentPlant.DataCore.Client.Clients;
+﻿using IntelligentPlant.DataCore.Client.Clients;
 
 namespace IntelligentPlant.IndustrialAppStore.Client.Clients {
 

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/OrganizationInfoClient.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/OrganizationInfoClient.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Net.Http;
-using System.Net.Http.Formatting;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 
 using IntelligentPlant.DataCore.Client;
 using IntelligentPlant.IndustrialAppStore.Client.Model;

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/UserInfoClient.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Clients/UserInfoClient.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
-using IntelligentPlant.DataCore.Client;
+﻿using IntelligentPlant.DataCore.Client;
 using IntelligentPlant.IndustrialAppStore.Client.Model;
 
 namespace IntelligentPlant.IndustrialAppStore.Client.Clients {

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/IndustrialAppStoreHttpClient.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/IndustrialAppStoreHttpClient.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Net.Http;
-
-using IntelligentPlant.DataCore.Client;
+﻿using IntelligentPlant.DataCore.Client;
 using IntelligentPlant.IndustrialAppStore.Client.Clients;
 
 namespace IntelligentPlant.IndustrialAppStore.Client {

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/IndustrialAppStoreHttpClientExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/IndustrialAppStoreHttpClientExtensions.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Threading;
-using System.Threading.Tasks;
-using IntelligentPlant.DataCore.Client;
+﻿using System.ComponentModel.DataAnnotations;
+
 using IntelligentPlant.IndustrialAppStore.Client.Clients;
 using IntelligentPlant.IndustrialAppStore.Client.Model;
 using IntelligentPlant.IndustrialAppStore.Client.Queries;

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/IndustrialAppStoreHttpClientOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/IndustrialAppStoreHttpClientOptions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 
 using IntelligentPlant.DataCore.Client;
 

--- a/src/IntelligentPlant.IndustrialAppStore.HttpClient/Model/PagedApiResponse.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.HttpClient/Model/PagedApiResponse.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace IntelligentPlant.IndustrialAppStore.Client.Model {
+﻿namespace IntelligentPlant.IndustrialAppStore.Client.Model {
     /// <summary>
     /// A response containing a page of items.
     /// </summary>


### PR DESCRIPTION
Use of default usings in project files means that a lot of explicit namespace imports can be removed.