### PR TITLE
Mitigate vulnerabilities in upstream packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,13 +9,13 @@
     <PackageVersion Include="IntelligentPlant.Relativity" Version="2.0.0" />
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="2.2.0" />
     <PackageVersion Include="Jaahas.OpenTelemetry.Extensions" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.10" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
@@ -25,7 +25,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.6" />
+    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
@@ -39,5 +39,6 @@
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Net.Http.Json" Version="8.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/src/IntelligentPlant.DataCore.HttpClient/IntelligentPlant.DataCore.HttpClient.csproj
+++ b/src/IntelligentPlant.DataCore.HttpClient/IntelligentPlant.DataCore.HttpClient.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.ComponentModel.Annotations" />
     <PackageReference Include="System.Net.Http.Json" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/Http/HttpClientExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/Http/HttpClientExtensions.cs
@@ -61,7 +61,7 @@ namespace IntelligentPlant.IndustrialAppStore.CommandLine.Http {
             };
 
             if (!string.IsNullOrEmpty(options.ClientSecret)) {
-                authorizeRequestBody["client_secret"] = options.ClientSecret;
+                authorizeRequestBody["client_secret"] = options.ClientSecret!;
             }
 
             if (options.Scopes != null && options.Scopes.Any()) {
@@ -92,7 +92,7 @@ namespace IntelligentPlant.IndustrialAppStore.CommandLine.Http {
             };
 
             if (!string.IsNullOrEmpty(options.ClientSecret)) {
-                tokenRequestBody["client_secret"] = options.ClientSecret;
+                tokenRequestBody["client_secret"] = options.ClientSecret!;
             }
 
             var interval = deviceAuthorizationResponse.Interval ?? 5;


### PR DESCRIPTION
This PR mitigates some vulnerabilities in upstream packages related to System.Text.Json. These vulnerabilities were already mitigated at runtime since System.Text.Json 8.0.5 was already transitively referenced from elsewhere but these changes remove the build warnings without having to suppress them.