### PR TITLE
HTTP factory improvements

### DIFF
--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/DefaultIndustrialAppStoreHttpFactory.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/DefaultIndustrialAppStoreHttpFactory.cs
@@ -5,6 +5,22 @@ namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
     /// <summary>
     /// Default implementation of <see cref="IIndustrialAppStoreHttpFactory"/>.
     /// </summary>
+    /// <remarks>
+    /// 
+    /// <para>
+    ///   <see cref="DefaultIndustrialAppStoreHttpFactory"/> uses the <see cref="AccessTokenProvider"/> 
+    ///   service to retrieve access tokens to use when authenticating outgoing requests.
+    /// </para>
+    /// 
+    /// <para>
+    ///   The primary <see cref="HttpMessageHandler"/> for <see cref="HttpClient"/> instances 
+    ///   created by a <see cref="DefaultIndustrialAppStoreHttpFactory"/> is created using an 
+    ///   <see cref="IHttpMessageHandlerFactory"/>. This allows the same primary handler to be 
+    ///   re-used across multiple <see cref="HttpClient"/> instances while allowing each instance 
+    ///   to define its own handler for applying authentication headers.
+    /// </para>
+    /// 
+    /// </remarks>
     public sealed class DefaultIndustrialAppStoreHttpFactory : IndustrialAppStoreHttpFactory {
 
         /// <summary>
@@ -22,7 +38,7 @@ namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
         /// <param name="accessTokenProvider">
         ///   The access token provider to use.
         /// </param>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   <paramref name="httpMessageHandlerFactory"/> is <see langword="null"/>.
         /// </exception>
         public DefaultIndustrialAppStoreHttpFactory(IHttpMessageHandlerFactory httpMessageHandlerFactory, AccessTokenProvider accessTokenProvider)

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IIndustrialAppStoreHttpFactory.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IIndustrialAppStoreHttpFactory.cs
@@ -9,8 +9,8 @@
     /// <para>
     ///   <see cref="IIndustrialAppStoreHttpFactory"/> allows the HTTP request pipeline for a 
     ///   client to be customised in ways that may not be possible when using <see cref="IHttpMessageHandlerFactory"/> 
-    ///   directly, such as adding custom scope-specific authentication headers to outgoing 
-    ///   requests.
+    ///   or <see cref="IHttpClientFactory"/> directly, such as adding custom scope-specific 
+    ///   authentication headers to outgoing requests.
     /// </para>
     /// 
     /// <para>
@@ -20,14 +20,6 @@
     /// 
     /// </remarks>
     public interface IIndustrialAppStoreHttpFactory {
-
-        /// <summary>
-        /// Creates a new HTTP message handler.
-        /// </summary>
-        /// <returns>
-        ///   The HTTP message handler.
-        /// </returns>
-        HttpMessageHandler CreateHandler();
 
         /// <summary>
         /// Creates a new <see cref="HttpClient"/> instance.

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreExtensions.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Extensions.DependencyInjection {
 
             builder.Services.TryAddScoped<DataCoreHttpClient>(provider => provider.GetRequiredService<IndustrialAppStoreHttpClient>());
 
-            var httpBuilder = builder.Services.AddHttpClient(nameof(IndustrialAppStoreHttpClient));
+            var httpBuilder = builder.Services.AddHttpClient(IndustrialAppStoreHttpFactory.HttpClientName);
             configureHttpBuilder?.Invoke(httpBuilder);
 
             return builder;
@@ -178,7 +178,8 @@ namespace Microsoft.Extensions.DependencyInjection {
         ///   The builder.
         /// </param>
         /// <param name="factory">
-        ///   The access token factory delegate.
+        ///   The access token factory delegate that the <see cref="AccessTokenProvider"/> should 
+        ///   use.
         /// </param>
         /// <returns>
         ///   The builder.
@@ -212,7 +213,7 @@ namespace Microsoft.Extensions.DependencyInjection {
         ///   The builder.
         /// </param>
         /// <param name="implementationFactory">
-        ///   A delegate that will create the access token factory.
+        ///   A delegate that will create the access token factory for the <see cref="AccessTokenProvider"/>.
         /// </param>
         /// <returns>
         ///   The builder.
@@ -236,6 +237,27 @@ namespace Microsoft.Extensions.DependencyInjection {
             });
 
             return builder;
+        }
+
+
+        /// <summary>
+        /// Registers a scoped <see cref="AccessTokenProvider"/> service with the builder that 
+        /// will always return the specified access token.
+        /// </summary>
+        /// <param name="builder">
+        ///   The builder.
+        /// </param>
+        /// <param name="accessToken">
+        ///   The access token to use.
+        /// </param>
+        /// <returns>
+        ///   The builder.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static IIndustrialAppStoreBuilder AddStaticAccessTokenProvider(this IIndustrialAppStoreBuilder builder, string? accessToken) {
+            return builder.AddAccessTokenProvider(AccessTokenProvider.CreateStaticAccessTokenFactory(accessToken));
         }
 
     }

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreHttpFactory.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreHttpFactory.cs
@@ -9,6 +9,13 @@ namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
     public abstract class IndustrialAppStoreHttpFactory : IIndustrialAppStoreHttpFactory {
 
         /// <summary>
+        /// The name of the <see cref="IHttpMessageHandlerFactory"/> configuration to use when 
+        /// creating <see cref="HttpMessageHandler"/>s
+        /// </summary>
+        internal const string HttpClientName = nameof(IndustrialAppStoreHttpClient);
+
+
+        /// <summary>
         /// The HTTP message handler factory.
         /// </summary>
         private readonly IHttpMessageHandlerFactory _httpMessageHandlerFactory;
@@ -34,7 +41,7 @@ namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
         /// <returns>
         ///   The HTTP message handler.
         /// </returns>
-        protected virtual HttpMessageHandler CreateHandler() => _httpMessageHandlerFactory.CreateHandler(nameof(IndustrialAppStoreHttpClient));
+        protected virtual HttpMessageHandler CreateHandler() => _httpMessageHandlerFactory.CreateHandler(HttpClientName);
 
 
         /// <summary>
@@ -44,17 +51,31 @@ namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
         ///   The <see cref="HttpClient"/> instance.
         /// </returns>
         protected virtual HttpClient CreateClient() {
-            var http = new HttpClient(CreateHandler(), false);
-#if NET8_0_OR_GREATER
-            http.DefaultRequestVersion = System.Net.HttpVersion.Version11;
-            http.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
-#endif
-            return http;
+            var httpClient = new HttpClient(CreateHandler(), false);
+            ConfigureHttpClient(httpClient);
+            return httpClient;
         }
 
 
-        /// <inheritdoc/>
-        HttpMessageHandler IIndustrialAppStoreHttpFactory.CreateHandler() => CreateHandler();
+        /// <summary>
+        /// Configures the specified <see cref="HttpClient"/> instance.
+        /// </summary>
+        /// <param name="httpClient">
+        ///   The <see cref="HttpClient"/> instance to configure.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="httpClient"/> is <see langword="null"/>.
+        /// </exception>
+        protected virtual void ConfigureHttpClient(HttpClient httpClient) {
+            if (httpClient == null) {
+                throw new ArgumentNullException(nameof(httpClient));
+            }
+
+#if NET8_0_OR_GREATER
+            httpClient.DefaultRequestVersion = System.Net.HttpVersion.Version11;
+            httpClient.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+#endif
+        }
 
 
         /// <inheritdoc/>

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/PACKAGE_README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/PACKAGE_README.md
@@ -15,7 +15,7 @@ Please consider using one of the following packages instead of using this packag
 
 # Getting Started
 
-To register a scoped `IndustrialAppStoreHttpClient` service with an `IServiceCollection`, call the `AddIndustrialAppStoreServices` extension method:
+To register a scoped `IndustrialAppStoreHttpClient` service with an `IServiceCollection`, call the `AddIndustrialAppStoreApiServices` extension method:
 
 ```csharp
 var builder = services.AddIndustrialAppStoreApiServices();
@@ -53,6 +53,7 @@ var builder = services
         return (CancellationToken ct) => accessTokenService.GetAccessTokenAsync(ct);
     });
 ```
+
 
 ## Manually setting the access token factory
 


### PR DESCRIPTION
This PR simplifies the `IIndustrialAppStoreHttpFactory` interface so that only a `CreateClient` method is required and improves some implementation details such as using a constant value to define the HTTP client name that the default factory implementation requests from `IHttpMessageHandlerFactory`.