### PR TITLE
Add app data folder provider for CLI apps

### DIFF
--- a/docs/migration-guides/v2-v3.md
+++ b/docs/migration-guides/v2-v3.md
@@ -54,36 +54,32 @@ You will likely have to refactor all API calls in your application (in particula
 
 Instead of passing a context parameter to each API call to provide authentication information, both `IndustrialAppStoreHttpClient` and `DataCoreHttpClient` now expect the `HttpClient` passed to their constructor to be pre-configured to supply all the authentication information required to be able to authenticate outgoing requests.
 
+In ASP.NET Core applications that use the IntelligentPlant.IndustrialAppStore.Authentication library, the `HttpClient` used to construct the API client is now automatically configured to use a bearer token for the calling user, obtained from the scoped `ITokenStore` service.
+
 If you are not using dependency injection to create `IndustrialAppStoreHttpClient` or `DataCoreHttpClient` instances, you can manually modify default request headers on the `HttpClient` used by the API client, or use a custom `DelegatingHandler` to modify outgoing requests.
 
-If you are using dependency injection in your application, you can replace the `IIndustrialAppStoreHttpFactory` service type with a custom implementation. `IIndustrialAppStoreHttpFactory` is used by the DI system to create `HttpMessageHandler` instances for `IndustrialAppStoreHttpClient` and `DataCoreHttpClient` instances. The default implementation simply uses the `Microsoft.Extensions.Http.IHttpMessageHandlerFactory` service to create shared `HttpMessageHandler` instances. You can replace this service with a custom implementation that creates `HttpMessageHandler` instances with the required authentication headers.
+
+# Command-Line Apps
+
+The new IntelligentPlant.IndustrialAppStore.CommandLine library provides dependency injection extensions to simplify registering Industrial App Store services for use in command-line applications. This includes the ability to sign a command-line application into the Industrial App Store using the OAuth 2.0 device code authorization grant:
 
 ```csharp
-builder.Services
-    .AddIndustrialAppStoreAuthentication(options => {
-        // Configure options as normal here.
-    })
-    .AddHttpFactory<MyHttpFactory>();
+services.AddIndustrialAppStoreCliServices(options => {
+    options.ClientId = "<YOUR CLIENT ID>";
+    // Folder that encrypted authentication tokens will be saved to. Relative 
+    // paths are resolved using the user's local application data folder.
+    options.AppDataPath = "MyIasApp";
+});
 
+var provider = services.BuildServiceProvider();
+using var scope = provider.CreateScope();
 
-internal sealed class MyHttpFactory : IndustrialAppStoreHttpFactory {
+var sessionManager = scope.ServiceProvider.GetRequiredService<IndustrialAppStoreSessionManager>();
+await sessionManager.SignInAsync((request, ct) => {
+    Console.WriteLine($"Please sign in by visiting {request.VerificationUri} and entering the following code: {request.UserCode}");
+    return default;
+});
 
-    public MyHttpFactory(IHttpMessageHandlerFactory handlerFactory) 
-        : base(handlerFactory) { }
-
-    protected override HttpMessageHandler CreateHandler() {
-        // Base implementation obtains a shared handler instance 
-        // from the IHttpMessageHandlerFactory
-        var primaryHandler = base.CreateHandler();
-
-        // MyDelegatingHandler is a custom DelegatingHandler that 
-        // sets authentication headers on outgoing requests.
-        var accessTokenHandler = new MyDelegatingHandler();
-        accessTokenHandler.InnerHandler = primaryHandler;
-        return accessTokenHandler;
-    }
-
-}
+var client = scope.ServiceProvider.GetRequiredService<IndustrialAppStoreHttpClient>();
+var dataSources = await client.DataSources.GetDataSourcesAsync();
 ```
-
-> Note that in ASP.NET Core applications that use the IntelligentPlant.IndustrialAppStore.Authentication library, it is not necessary to manually replace the default `IIndustrialAppStoreHttpFactory` service. The library automatically replaces the default service with one that uses the registered `ITokenStore` service to obtain access tokens for outgoing API requests.

--- a/samples/ExampleCliApplication/appsettings.json
+++ b/samples/ExampleCliApplication/appsettings.json
@@ -1,6 +1,6 @@
 ﻿{
   "IAS": {
     "ClientId": "<YOUR CLIENT ID>",
-    "TokenPath": "Industrial App Store/ExampleCliApplication/tokens"
+    "AppDataPath": "Industrial App Store/ExampleCliApplication"
   }
 }

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/AppDataFolderProvider.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/AppDataFolderProvider.cs
@@ -1,0 +1,51 @@
+﻿namespace IntelligentPlant.IndustrialAppStore.CommandLine {
+
+    /// <summary>
+    /// <see cref="AppDataFolderProvider"/> defines the base folder that will be used to store 
+    /// application data such as authentication tokens.
+    /// </summary>
+    public class AppDataFolderProvider {
+
+        /// <summary>
+        /// The data folder.
+        /// </summary>
+        public DirectoryInfo? AppDataFolder { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="AppDataFolderProvider"/> instance.
+        /// </summary>
+        /// <param name="dataFolder">
+        ///   The data folder.
+        /// </param>
+        public AppDataFolderProvider(DirectoryInfo? dataFolder) {
+            AppDataFolder = dataFolder;
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="AppDataFolderProvider"/> instance from the specified path.
+        /// </summary>
+        /// <param name="dataFolderPath">
+        ///   The data folder path.
+        /// </param>
+        /// <remarks>
+        ///   If a relative path is specified, it will be made absolute relative to <see cref="Environment.SpecialFolder.LocalApplicationData"/> 
+        ///   if <see cref="Environment.UserInteractive"/> is <see langword="true"/>, and relative 
+        ///   to <see cref="Environment.SpecialFolder.CommonApplicationData"/> otherwise.
+        /// </remarks>
+        internal AppDataFolderProvider(string? dataFolderPath) {
+            if (!string.IsNullOrWhiteSpace(dataFolderPath)) {
+                var fullPath = Path.IsPathRooted(dataFolderPath)
+                    ? dataFolderPath
+                    : Path.Combine(
+                        Environment.UserInteractive
+                            ? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)
+                            : Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData),
+                        dataFolderPath);
+                AppDataFolder = new DirectoryInfo(fullPath);
+            }
+        }
+
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreCliExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreCliExtensions.cs
@@ -63,6 +63,11 @@ namespace Microsoft.Extensions.DependencyInjection {
 
             builder.Services.AddSingleton(provider => {
                 var options = provider.GetRequiredService<IOptions<IndustrialAppStoreSessionManagerOptions>>().Value;
+                return new AppDataFolderProvider(options.AppDataPath);
+            });
+
+            builder.Services.AddSingleton(provider => {
+                var options = provider.GetRequiredService<IOptions<IndustrialAppStoreSessionManagerOptions>>().Value;
                 return ActivatorUtilities.CreateInstance<IndustrialAppStoreSessionManager>(provider, options);
             });
 

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManagerOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManagerOptions.cs
@@ -43,13 +43,19 @@ namespace IntelligentPlant.IndustrialAppStore.CommandLine {
         public string[]? Scopes { get; set; }
 
         /// <summary>
-        /// The path to the folder where tokens will be stored.
+        /// The path to the folder where application data such as authentication tokens will be 
+        /// stored.
         /// </summary>
         /// <remarks>
         /// 
         /// <para>
-        ///   If <see cref="TokenPath"/> is <see langword="null"/>, tokens will not be persisted 
-        ///   and a new authentication session must be created each time the application runs.
+        ///   Authentication tokens will be stored in a <c>.tokens</c> folder under this path.
+        /// </para>
+        /// 
+        /// <para>
+        ///   If <see cref="AppDataPath"/> is <see langword="null"/> or white space, tokens will not 
+        ///   be persisted and a new authentication session must be created each time the 
+        ///   application runs.
         /// </para>
         /// 
         /// <para>
@@ -59,7 +65,7 @@ namespace IntelligentPlant.IndustrialAppStore.CommandLine {
         /// </para>
         /// 
         /// </remarks>
-        public string? TokenPath { get; set; }
+        public string? AppDataPath { get; set; }
 
     }
 }

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/PACKAGE_README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/PACKAGE_README.md
@@ -14,9 +14,10 @@ Next, register CLI services with the dependency injection container:
 ```csharp
 services.AddIndustrialAppStoreCliServices(options => {
     options.ClientId = "<YOUR CLIENT ID>";
-    // Folder that encrypted authentication tokens will be saved to. Relative 
-    // paths are resolved using the user's local application data folder.
-    options.TokenPath = "MyIasApp/tokens";
+    // Base folder for application data such as encrypted authentication 
+    // tokens. Relative paths are resolved using the user's local 
+    // application data folder.
+    options.AppDataPath = "MyIasApp";
 });
 ```
 
@@ -39,3 +40,15 @@ Finally, use the `IndustrialAppStoreHttpClient` service to interact with the Ind
 var client = scope.ServiceProvider.GetRequiredService<IndustrialAppStoreHttpClient>();
 var dataSources = await client.DataSources.GetDataSourcesAsync();
 ```
+
+
+# Persisting Application Data
+
+If your application persists data to disk, you can use the `AppDataFolderProvider` service to get the base path for your app's data folder:
+
+```csharp
+var appDataDir = scope.ServiceProvider.GetRequiredService<AppDataFolderProvider>().AppDataFolder;
+var myDataDir = appDataDir.CreateSubdirectory("MyData");
+```
+
+Encrypted authentication tokens are saved to a sub-folder of the base folder provided by `AppDataFolderProvider`.

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/README.md
@@ -17,8 +17,10 @@ First, register CLI services with the dependency injection container:
 ```csharp
 services.AddIndustrialAppStoreCliServices(options => {
     options.ClientId = "<YOUR CLIENT ID>";
-    // Relative paths are resolved using the user's local application data folder.
-    options.TokenPath = "MyIasApp/tokens";
+    // Base folder for application data such as encrypted authentication 
+    // tokens. Relative paths are resolved using the user's local 
+    // application data folder.
+    options.AppDataPath = "MyIasApp";
 });
 ```
 
@@ -41,3 +43,15 @@ Finally, use the `IndustrialAppStoreHttpClient` service to interact with the Ind
 var client = scope.ServiceProvider.GetRequiredService<IndustrialAppStoreHttpClient>();
 var dataSources = await client.DataSources.GetDataSourcesAsync();
 ```
+
+
+# Persisting Application Data
+
+If your application persists data to disk, you can use the `AppDataFolderProvider` service to get the base path for your app's data folder:
+
+```csharp
+var appDataDir = scope.ServiceProvider.GetRequiredService<AppDataFolderProvider>().AppDataFolder;
+var myDataDir = appDataDir.CreateSubdirectory("MyData");
+```
+
+Encrypted authentication tokens are saved to a sub-folder of the base folder provided by `AppDataFolderProvider`.

--- a/src/IntelligentPlant.IndustrialAppStore.Templates/src/iascli/README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.Templates/src/iascli/README.md
@@ -34,12 +34,12 @@ Next, you must update the `appsettings.json` file (in the same folder as this RE
 {
     "IAS": {
         "ClientId": "<YOUR CLIENT ID>",
-        "TokenPath": "<PATH TO SAVE AUTHENTICATION TOKENS TO>"
+        "AppDataPath": "<BASE PATH TO SAVE APPLICATION DATA TO>"
     }
 }
 ```
 
-The `TokenPath` setting specifies the path where the app will save authentication tokens to. This is required in order to persist the authentication tokens between app runs. Specifying a relative path will save the tokens relative to the user's local application data folder.
+The `AppDataPath` setting specifies the base path where the app will save app data such as authentication tokens to. This is required in order to persist the authentication tokens between app runs. Relative paths are made absolute using the user's local application data folder (for interactive environments) or the common application data folder (for non-interactive environments).
 
 
 # Authentication


### PR DESCRIPTION
This PR adds a new `AppDataFolderProvider` singleton service to the command-line library that provides the base folder that the app should save data to (such as authentication tokens). Apps can inject or retrieve this service and use to to get the base path for their own application data.

The `IndustrialAppStoreSessionManager` service has been modified to store tokens in a `.tokens` folder under the base app data folder.