### PR TITLE
Session manager can return session info

### DIFF
--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManager.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManager.cs
@@ -336,5 +336,27 @@ namespace IntelligentPlant.IndustrialAppStore.CommandLine {
             _tokens = null;
         }
 
+
+        /// <summary>
+        /// Gets information about the active authentication session.
+        /// </summary>
+        /// <param name="cancellationToken">
+        ///   The cancellation token for the operation.
+        /// </param>
+        /// <returns>
+        ///   A <see cref="ValueTask{TResult}"/> that returns the session information, or 
+        ///   <see langword="null"/> if no session exists.
+        /// </returns>
+        public async ValueTask<SessionInfo?> GetSessionInfoAsync(CancellationToken cancellationToken) {
+            using var handle = await _tokensLock.LockAsync(cancellationToken).ConfigureAwait(false);
+            var tokens = _tokens ??= LoadTokens();
+
+            if (tokens == null) {
+                return null;
+            }
+
+            return new SessionInfo(tokens.UtcExpiresAt, !string.IsNullOrWhiteSpace(tokens.RefreshToken));
+        }
+
     }
 }

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/SessionInfo.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/SessionInfo.cs
@@ -1,0 +1,34 @@
+﻿namespace IntelligentPlant.IndustrialAppStore.CommandLine {
+
+    /// <summary>
+    /// Provides basic information about an Industrial App Store authentication session.
+    /// </summary>
+    public readonly struct SessionInfo {
+
+        /// <summary>
+        /// The expiry time for the session.
+        /// </summary>
+        public DateTimeOffset? ExpiresAt { get; }
+
+        /// <summary>
+        /// Specifies if the session has a refresh token.
+        /// </summary>
+        public bool HasRefreshToken { get; }
+
+
+        /// <summary>
+        /// Creates a new <see cref="SessionInfo"/> instance.
+        /// </summary>
+        /// <param name="expiresAt">
+        ///   The expiry time for the session.
+        /// </param>
+        /// <param name="hasRefreshToken">
+        ///   Specifies if the session has a refresh token.
+        /// </param>
+        public SessionInfo(DateTimeOffset? expiresAt, bool hasRefreshToken) {
+            ExpiresAt = expiresAt;
+            HasRefreshToken = hasRefreshToken;
+        }
+
+    }
+}


### PR DESCRIPTION
This PR adds a `GetSessionInfoAsync` method to `IndustrialAppStoreSessionManager` that allows basic session information (expiry time, whether or not a refresh token is available) to be returned.