### PR TITLE
Authentication cookie expiry is now configurable

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 3,
-  "Minor": 0,
+  "Minor": 1,
   "Patch": 0,
   "PreRelease": ""
 }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptions.cs
@@ -97,6 +97,15 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         public bool ShowConsentPrompt { get; set; }
 
         /// <summary>
+        /// The expiry time for the cookie used to store the user's session.
+        /// </summary>
+        /// <remarks>
+        ///  If <see langword="null"/>, the cookie will use the default expiry period for an 
+        ///  ASP.NET Core authentication cookie.
+        /// </remarks>
+        public TimeSpan? CookieExpiry { get; set; }
+
+        /// <summary>
         /// Additional event handlers for cookie authentication events raised by the application.
         /// </summary>
         /// <remarks>

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/Options/PostConfigureIasCookieAuthenticationOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/Options/PostConfigureIasCookieAuthenticationOptions.cs
@@ -31,6 +31,10 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication.Options {
                 options.LoginPath = iasOptions.LoginPath;
             }
 
+            if (iasOptions.CookieExpiry.HasValue) {
+                options.ExpireTimeSpan = iasOptions.CookieExpiry.Value;
+            }
+
             var cookieEvents = iasOptions.CookieAuthenticationEvents ?? new CookieAuthenticationEvents();
 
             options.Events = new CookieAuthenticationEvents() {


### PR DESCRIPTION
This PR adds a `CookieExpiry` property to `IndustrialAppStoreAuthenticationOptions`. If set, it modifies the expiry time for the authentication cookie using the internal `PostConfigureIasCookieAuthenticationOptions` class.

The default behaviour is to use the default ASP.NET Core expiry time (14 days).