### PR TITLE
Token handling improvements and package updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,16 +6,16 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="IntelligentPlant.ProblemDetails.Core" Version="4.0.0" />
-    <PackageVersion Include="IntelligentPlant.Relativity" Version="2.0.0" />
-    <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="2.2.0" />
+    <PackageVersion Include="IntelligentPlant.Relativity" Version="3.0.0" />
+    <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="3.0.1" />
     <PackageVersion Include="Jaahas.OpenTelemetry.Extensions" Version="2.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.13" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />

--- a/build.cake
+++ b/build.cake
@@ -73,7 +73,7 @@ const string VersionFile = "./build/version.json";
 // 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-#load nuget:?package=Jaahas.Cake.Extensions&version=3.1.0
+#load nuget:?package=Jaahas.Cake.Extensions&version=4.0.1
 
 // Bootstrap build context and tasks.
 Bootstrap(DefaultSolutionFile, VersionFile);

--- a/build/version.json
+++ b/build/version.json
@@ -2,5 +2,5 @@
   "Major": 3,
   "Minor": 3,
   "Patch": 0,
-  "PreRelease": ""
+  "PreRelease": "pre"
 }

--- a/samples/CustomTokenStoreExample/Services/EFTokenStore.cs
+++ b/samples/CustomTokenStoreExample/Services/EFTokenStore.cs
@@ -50,8 +50,8 @@ namespace ExampleMvcApplication.Services {
             // Decrypt access token and refresh token.
             return new OAuthTokens(
                 dbTokens.TokenType, 
-                dbTokens.AccessToken = UnprotectToken(dbTokens.AccessToken)!, 
-                dbTokens.RefreshToken = UnprotectToken(dbTokens.RefreshToken), 
+                UnprotectToken(dbTokens.AccessToken)!, 
+                UnprotectToken(dbTokens.RefreshToken), 
                 dbTokens.ExpiryTime
             );
         }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/TokenStore.cs
@@ -131,7 +131,14 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
                 return oauthTokens;
             }
 
-            if (oauthTokens.Value.UtcExpiresAt.Value > DateTime.UtcNow) {
+            // If we have a refresh token, we will assume that the access token has expired 30
+            // seconds before it actually does. This is designed to prevent last-minute expiry
+            // issues caused by e.g. clocks being slightly out of sync.
+            var tokenExpiryComparisonTime = string.IsNullOrWhiteSpace(oauthTokens.Value.RefreshToken)
+                ? _timeProvider.GetUtcNow()
+                : _timeProvider.GetUtcNow().AddSeconds(30);
+
+            if (oauthTokens.Value.UtcExpiresAt.Value > tokenExpiryComparisonTime) {
                 // Access token is still valid.
                 return oauthTokens;
             }

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManager.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/IndustrialAppStoreSessionManager.cs
@@ -202,7 +202,14 @@ namespace IntelligentPlant.IndustrialAppStore.CommandLine {
                 return null;
             }
 
-            if (!tokens.UtcExpiresAt.HasValue || tokens.UtcExpiresAt.Value > _timeProvider.GetUtcNow()) {
+            // If we have a refresh token, we will assume that the access token has expired 30
+            // seconds before it actually does. This is designed to prevent last-minute expiry
+            // issues caused by e.g. clocks being slightly out of sync.
+            var tokenExpiryComparisonTime = string.IsNullOrWhiteSpace(tokens.RefreshToken) 
+                ? _timeProvider.GetUtcNow() 
+                : _timeProvider.GetUtcNow().AddSeconds(30);
+
+            if (!tokens.UtcExpiresAt.HasValue || tokens.UtcExpiresAt.Value > tokenExpiryComparisonTime) {
                 return tokens.AccessToken;
             }
 


### PR DESCRIPTION
`TokenStore` and `IndustrialAppStoreSessionManager` will now assume that access tokens expire 30 seconds before their actual expiry time if a refresh token is also available.

This is designed to help prevent failed requests when an access token is used very close to its expiry time, due to e.g. clock drift between client and server.

Updated versions in `Directory.Packages.props` for several NuGet packages, including  `IntelligentPlant.Relativity` (to `3.0.0`) and `Jaahas.HttpRequestTransformer` (to `3.0.1`).

Upgraded `Microsoft.AspNetCore.*` packages and `Microsoft.EntityFrameworkCore.Sqlite` to `8.0.13`.

Modified `build.cake` to change `Jaahas.Cake.Extensions` version from `3.1.0` to `4.0.1`.