### PR TITLE
Remove pre-release flag from v3.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
     building via build.ps1 or build.sh. It is defined here to allow Visual Studio to build  
     the solution with the correct version number.
     -->
-    <Version>3.0.0</Version>
+    <Version>3.3.0</Version>
   </PropertyGroup>
 
   <Choose>

--- a/build/version.json
+++ b/build/version.json
@@ -2,5 +2,5 @@
   "Major": 3,
   "Minor": 3,
   "Patch": 0,
-  "PreRelease": "pre"
+  "PreRelease": ""
 }


### PR DESCRIPTION
This PR removes the `pre` version flag from the v3.3.0 packages.