### PR TITLE
Example CLI app handles sign-in cancellation

### DIFF
--- a/samples/ExampleCliApplication/Program.cs
+++ b/samples/ExampleCliApplication/Program.cs
@@ -19,11 +19,17 @@ var provider = services.BuildServiceProvider();
 using var scope = provider.CreateScope();
 
 var sessionManager = scope.ServiceProvider.GetRequiredService<IndustrialAppStoreSessionManager>();
-await sessionManager.SignInAsync((request, ct) => {
-    Console.WriteLine($"Please sign in by visiting {request.VerificationUri} and entering the following code: {request.UserCode}");
-    Console.WriteLine();
-    return default;
-});
+try {
+    await sessionManager.SignInAsync((request, ct) => {
+        Console.WriteLine($"Please sign in by visiting {request.VerificationUri} and entering the following code: {request.UserCode}");
+        Console.WriteLine();
+        return default;
+    });
+}
+catch (OperationCanceledException) {
+    Console.WriteLine("Sign-in cancelled.");
+    return 1;
+}
 
 var client = scope.ServiceProvider.GetRequiredService<IndustrialAppStoreHttpClient>();
 var userInfo = await client.UserInfo.GetUserInfoAsync();
@@ -31,3 +37,5 @@ var userInfo = await client.UserInfo.GetUserInfoAsync();
 Console.WriteLine("User Information:");
 Console.WriteLine();
 Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(userInfo, new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web) { WriteIndented = true }));
+
+return 0;


### PR DESCRIPTION
Updates the example CLI application so that cancellation/timeout of a sign-in request is directly handled in the app instead of causing an unhandled exception to be thrown.