### PR TITLE
Add Labels property to tag objects

### DIFF
--- a/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchResult.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/TagSearchResult.cs
@@ -55,11 +55,16 @@ namespace IntelligentPlant.DataCore.Client.Model {
 
         }
 
+        /// <summary>
+        /// The labels for the tag.
+        /// </summary>
+        public ICollection<string>? Labels { get; set; }
+
 
         /// <summary>
         /// Creates a new <see cref="TagSearchResult"/> object.
         /// </summary>
-        public TagSearchResult() : this(null) {}
+        public TagSearchResult() : this(null) { }
 
 
         /// <summary>
@@ -76,6 +81,7 @@ namespace IntelligentPlant.DataCore.Client.Model {
             UnitOfMeasure = other.UnitOfMeasure;
             Properties = other.Properties;
             DigitalStates = other.DigitalStates;
+            Labels = other.Labels;
         }
 
 


### PR DESCRIPTION
This PR updates the `TagSearchResult` type to include a `Labels` property.