### PR TITLE
Experimental Semantic Kernel extensions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.45.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
@@ -36,6 +37,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Net.Http.Json" Version="8.0.1" />

--- a/IntelligentPlant.IndustrialAppStore.ClientTools.sln
+++ b/IntelligentPlant.IndustrialAppStore.ClientTools.sln
@@ -66,6 +66,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleCliApplication", "sa
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntelligentPlant.IndustrialAppStore.CommandLine", "src\IntelligentPlant.IndustrialAppStore.CommandLine\IntelligentPlant.IndustrialAppStore.CommandLine.csproj", "{C8844839-3EA9-4CDD-AF2C-09B0B36AF60D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelligentPlant.IndustrialAppStore.SemanticKernel", "src\IntelligentPlant.IndustrialAppStore.SemanticKernel\IntelligentPlant.IndustrialAppStore.SemanticKernel.csproj", "{43D9E2E5-2EAC-40AB-BDAB-747E26082551}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -112,6 +114,10 @@ Global
 		{C8844839-3EA9-4CDD-AF2C-09B0B36AF60D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8844839-3EA9-4CDD-AF2C-09B0B36AF60D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8844839-3EA9-4CDD-AF2C-09B0B36AF60D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43D9E2E5-2EAC-40AB-BDAB-747E26082551}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43D9E2E5-2EAC-40AB-BDAB-747E26082551}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43D9E2E5-2EAC-40AB-BDAB-747E26082551}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43D9E2E5-2EAC-40AB-BDAB-747E26082551}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -128,6 +134,7 @@ Global
 		{8DFA78B8-1CE4-4764-B4EB-765EFEB95CD7} = {49E8C063-F41F-451F-81BF-C4960B9A0168}
 		{D2CB5AD0-64F8-4691-9BD3-A8E0719AE046} = {65FE3E10-29B7-4A78-9ED8-C8384AE9D420}
 		{C8844839-3EA9-4CDD-AF2C-09B0B36AF60D} = {49E8C063-F41F-451F-81BF-C4960B9A0168}
+		{43D9E2E5-2EAC-40AB-BDAB-747E26082551} = {49E8C063-F41F-451F-81BF-C4960B9A0168}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D12472DA-7354-4A19-8F60-4F9D42C71241}

--- a/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.DependencyInjection/IndustrialAppStoreExtensions.cs
@@ -260,5 +260,38 @@ namespace Microsoft.Extensions.DependencyInjection {
             return builder.AddAccessTokenProvider(AccessTokenProvider.CreateStaticAccessTokenFactory(accessToken));
         }
 
+
+        /// <summary>
+        /// Adds additional services to the <see cref="IIndustrialAppStoreBuilder"/>.
+        /// </summary>
+        /// <param name="builder">
+        ///   The builder.
+        /// </param>
+        /// <param name="configure">
+        ///   The callback that will be used to configure the additional services.
+        /// </param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="configure"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        ///   Calling <see cref="AddServices"/> is equivalent to adding services directly to <see cref="IIndustrialAppStoreBuilder.Services"/>, 
+        ///   but allows this to be done in a fluent manner.
+        /// </remarks>
+        public static IIndustrialAppStoreBuilder AddServices(this IIndustrialAppStoreBuilder builder, Action<IServiceCollection> configure) {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+            if (configure == null) {
+                throw new ArgumentNullException(nameof(configure));
+            }
+
+            configure.Invoke(builder.Services);
+            return builder;
+        }
+
     }
 }

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/DiagnosticCodes.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/DiagnosticCodes.cs
@@ -1,0 +1,15 @@
+﻿namespace IntelligentPlant.IndustrialAppStore.SemanticKernel {
+
+    /// <summary>
+    /// Code analysis diagnostic codes.
+    /// </summary>
+    public static class DiagnosticCodes {
+
+        /// <summary>
+        /// Semantic Kernel extensions are experimental and are subject to change or removal.
+        /// </summary>
+        public const string ExperimentalSemanticKernelExtensions = "IASSK0001";
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/IndustrialAppStoreBuilderSemanticKernelExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/IndustrialAppStoreBuilderSemanticKernelExtensions.cs
@@ -1,0 +1,133 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+using IntelligentPlant.IndustrialAppStore.SemanticKernel;
+using IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace IntelligentPlant.IndustrialAppStore.DependencyInjection {
+
+    /// <summary>
+    /// Extensions for configuring Semantic Kernel services for use with the Industrial App Store.
+    /// </summary>
+    [Experimental(DiagnosticCodes.ExperimentalSemanticKernelExtensions)]
+    public static class IndustrialAppStoreBuilderSemanticKernelExtensions {
+
+        /// <summary>
+        /// Registers a scoped <see cref="Kernel"/> service that can invoke Industrial App Store 
+        /// APIs when used with a tool-enabled Large Language Model (LLM).
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="IIndustrialAppStoreBuilder"/>.
+        /// </param>
+        /// <param name="configurePlugins">
+        ///   A callback that can be used to configure additional plugins to register with the 
+        ///   <see cref="Kernel"/>.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="IIndustrialAppStoreBuilder"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="builder"/> is <see langword="null"/>.
+        /// </exception>
+        public static IIndustrialAppStoreBuilder AddSemanticKernelServices(this IIndustrialAppStoreBuilder builder, Action<IServiceProvider, KernelPluginCollection>? configurePlugins = null) {
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            builder.Services.AddScoped<IndustrialAppStoreDataApiPlugin>();
+
+            builder.Services.AddScoped(provider => {
+                var plugins = new KernelPluginCollection().AddIndustrialAppStorePlugins(provider);
+                configurePlugins?.Invoke(provider, plugins);
+                return plugins;
+            });
+
+            builder.Services.AddScoped(provider => new Kernel(provider, provider.GetRequiredService<KernelPluginCollection>()));
+
+            return builder;
+        }
+
+
+        /// <summary>
+        /// Registers plugins for querying the Industrial App Store.
+        /// </summary>
+        /// <param name="plugins">
+        ///   The <see cref="KernelPluginCollection"/> to add the plugins to.
+        /// </param>
+        /// <param name="serviceProvider">
+        ///   The <see cref="IServiceProvider"/> to use to resolve the plugins and/or any 
+        ///   dependent services.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="KernelPluginCollection"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="plugins"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="serviceProvider"/> is <see langword="null"/>.
+        /// </exception>
+        public static KernelPluginCollection AddIndustrialAppStorePlugins(this KernelPluginCollection plugins, IServiceProvider serviceProvider) {
+            if (plugins == null) {
+                throw new ArgumentNullException(nameof(plugins));
+            }
+            if (serviceProvider == null) {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            plugins.AddFromType<IndustrialAppStoreDataApiPlugin>(IndustrialAppStoreDataApiPlugin.PluginName, serviceProvider);
+
+            return plugins;
+        }
+
+
+        /// <summary>
+        /// Adds system messages to the chat history that inform the LLM about Industrial App 
+        /// Store-specific features and requirements.
+        /// </summary>
+        /// <param name="chatHistory">
+        ///   The <see cref="ChatHistory"/> to add the system messages to.
+        /// </param>
+        /// <returns>
+        ///   The updated <see cref="ChatHistory"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="chatHistory"/> is <see langword="null"/>.
+        /// </exception>
+        public static ChatHistory AddIndustrialAppStoreSystemPrompt(this ChatHistory chatHistory) {
+            if (chatHistory == null) {
+                throw new ArgumentNullException(nameof(chatHistory));
+            }
+
+            chatHistory.AddSystemMessage(@"
+# Industrial App Store
+
+The Industrial App Store (IAS) is a data platform where organisations from industrial sectors such as energy and manufacturing publish time series data about their industrial processes. 
+
+# Your Role
+
+You are a helpful assistant whose role is to help the user to interrogate their available data sets. Consider the following points:
+
+- Unless the user informs you otherwise, assume that they are an educated professional with technical knownledge about their domain and/or data science and programming skills. 
+- Unless the user states that they are giving you an exact identifier for an entity such as a data source or tag, assume that you probably need to use a tool call to get the exact identifier(s) that you need. 
+- When making calls to the Industrial App Store, timestamps can be specified as absolute ISO 8601 timestamps or as relative times unless the function description states otherwise. 
+  - Relative times are specified in the format `<BASE>[<OFFSET>]`. 
+    - Valid base times are: NOW, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, YEAR. 
+      - Apart from NOW, the base times represent the start of the nearest time unit that they represent e.g. DAY is the start of the current day.
+    - Offsets use the format `<QUANTITY><UNIT>` where the quantity is a number and the unit can be: MS, S, M, H, D, W, MO, Y. 
+      - Fractional quantities are allowed for all units except for MO (months) and Y (years). 
+      - The same period of time can be written in multiple ways e.g. 1D and 24H are equivalent.
+  - Examples: NOW, NOW-1H, DAY+5.5H, YEAR+3MO
+- Sample intervals can be specified as .NET System.TimeSpan literals (e.g. 01:00:00 = 1 hour) or using a short-hard format (e.g. 1H = 1 hour).
+  - Short-hand intervals follow the same rules as relative timestamp offsets but the MO and Y units are not allowed.
+- For complex requests you may have to make a number of tool calls in sequence, and use the results of one tool call in the inputs to the next tool call.
+- Not all requests will require you to use tools. For example, users might ask questions about data sources, tags and values that were retrieved earlier in the conversation.");
+            
+            return chatHistory;
+        }
+
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/IntelligentPlant.IndustrialAppStore.SemanticKernel.csproj
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/IntelligentPlant.IndustrialAppStore.SemanticKernel.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <Description>Types and extensions for registering Industrial App Store API plugins with Microsoft.SemanticKernel.</Description>
+    <LangVersion>11.0</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
+    <PackageReference Include="Microsoft.SemanticKernel.Core" />
+    <PackageReference Include="PolySharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IntelligentPlant.IndustrialAppStore.DependencyInjection\IntelligentPlant.IndustrialAppStore.DependencyInjection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath=".\README.md" />
+  </ItemGroup>
+
+</Project>

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/FindTagsRequest.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/FindTagsRequest.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Describes a request to search for tags on a data source.")]
+    public record FindTagsRequest : PluginRequest {
+
+        [JsonPropertyName("data_source_id")]
+        [Description("The ID of the Industrial App Store data source to query.")]
+        public required string DataSourceId { get; init; }
+
+        [JsonPropertyName("name_filter")]
+        [Description("The tag name filter. The '*' character can be used as a multi-character wildcard e.g. '*.sensor-1.*' returns tags containing '.sensor-1.' in their name.")]
+        public string? Name { get; init; }
+
+        [JsonPropertyName("page")]
+        [Description("The results page to return. Specify 1 for the first page matching the search terms.")]
+        public int Page { get; init; } = 1;
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IasDataSourceDescriptor.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IasDataSourceDescriptor.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+using IntelligentPlant.DataCore.Client.Model;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Describes an Industrial App Store data source.")]
+    public record IasDataSourceDescriptor {
+
+        [JsonPropertyName("id")]
+        [Description("The unique identifier for the data source.")]
+        public required string Id { get; init; }
+
+        [JsonPropertyName("display_name")]
+        [Description("The display name for the data source.")]
+        public required string DisplayName { get; init; }
+
+        [JsonPropertyName("description")]
+        [Description("The description for the data source.")]
+        public string? Description { get; init; }
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IasDataValue.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IasDataValue.cs
@@ -1,0 +1,45 @@
+﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+using IntelligentPlant.DataCore.Client.Model;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Describes a data value associated with a tag on an Industrial App Store data source.")]
+    public record IasDataValue {
+
+        [JsonPropertyName("utc_sample_time")]
+        [Description("The UTC sample time for the data value.")]
+        public required DateTime UtcSampleTime { get; init; }
+
+        [JsonPropertyName("value")]
+        [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
+        [Description("The numeric value for the data value. The display_value field should be used for display purposes instead of the value field if it is defined.")]
+        public required double Value { get; init; }
+
+        [JsonPropertyName("display_value")]
+        [Description("The display value for the data value. The display_value field should be used for display purposes instead of the value field if it is defined.")]
+        public string? DisplayValue { get; init; }
+
+        [JsonPropertyName("quality")]
+        [Description("The quality associated with the sample (good/uncertain/bad). This indicates the trustworthiness of the value.")]
+        public string? Quality { get; init; }
+
+
+        internal static IasDataValue FromTagValue(TagValue value) {
+            return new IasDataValue() {
+                UtcSampleTime = value.UtcSampleTime,
+                Value = value.IsNumeric ? value.NumericValue : double.NaN,
+                DisplayValue = value.TextValue,
+                Quality = value.Status switch {
+                    TagValueStatus.Good => "good",
+                    TagValueStatus.Uncertain => "uncertain",
+                    TagValueStatus.Bad => "bad",
+                    _ => "unknown"
+                }
+            };
+        }
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IasDataValueCollection.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IasDataValueCollection.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Describes a collection of data values associated with a tag on an Industrial App Store data source.")]
+    public record IasDataValueCollection {
+
+        [JsonPropertyName("name")]
+        [Description("The name of the tag associated with the values.")]
+        public required string TagName { get; init; }
+
+        [JsonPropertyName("values")]
+        [Description("The data values.")]
+        public required IasDataValue[] Values { get; init; }
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IasTagDescriptor.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IasTagDescriptor.cs
@@ -1,0 +1,31 @@
+﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Describes a tag (i.e. an instrument or sensor) on an Industrial App Store data source.")]
+    public record IasTagDescriptor {
+
+        [JsonPropertyName("name")]
+        [Description("The name of the tag.")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("description")]
+        [Description("The tag description.")]
+        public string? Description { get; init; }
+
+        [JsonPropertyName("units")]
+        [Description("The unit of measure for the tag.")]
+        public string? Units { get; init; }
+
+        [JsonPropertyName("labels")]
+        [Description("The labels for the tag. Labels can be used to group similar or related tags together.")]
+        public string[]? Labels { get; init; }
+
+        [JsonPropertyName("states")]
+        [Description("Some tags define discrete named states. When discrete states are defined, the value of the tag must map to one of the known states.")]
+        public IasTagDiscreteState[]? States { get; init; }
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IasTagDiscreteState.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IasTagDiscreteState.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Describes a named discrete state associated with a tag on an Industrial App Store data source.")]
+    public record IasTagDiscreteState {
+
+        [JsonPropertyName("name")]
+        [Description("The name of the discrete state.")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("value")]
+        [Description("The value for the state.")]
+        public required int Value { get; init; }
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IndustrialAppStoreDataApiPlugin.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/IndustrialAppStoreDataApiPlugin.cs
@@ -1,0 +1,110 @@
+﻿using System.ComponentModel;
+
+using IntelligentPlant.DataCore.Client;
+using IntelligentPlant.IndustrialAppStore.Client;
+
+using Microsoft.SemanticKernel;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Defines functions for interacting with the Industrial App Store.")]
+    internal class IndustrialAppStoreDataApiPlugin {
+
+        public const string PluginName = "industrial_app_store";
+
+        private readonly IndustrialAppStoreHttpClient _iasClient;
+
+        private readonly TimeProvider _timeProvider;
+
+
+        public IndustrialAppStoreDataApiPlugin(IndustrialAppStoreHttpClient iasClient, TimeProvider timeProvider) {
+            _iasClient = iasClient;
+            _timeProvider = timeProvider;
+        }
+
+
+        [KernelFunction("get_current_time")]
+        [Description("Gets the current UTC date and time. Use this function when you need to know what time it is before calling a function that requires a time range.")]
+        public DateTime GetCurrentTime(PluginRequest request) => _timeProvider.GetUtcNow().UtcDateTime;
+
+
+        [KernelFunction("get_data_sources")]
+        [Description("Gets the available Industrial App Store data sources.")]
+        public async Task<IEnumerable<IasDataSourceDescriptor>> GetDataSourcesAsync(PluginRequest request, CancellationToken cancellationToken) {
+            var result = await _iasClient.DataSources.GetDataSourcesAsync(cancellationToken);
+            return result.Select(x => new IasDataSourceDescriptor() {
+                Id = x.Name.QualifiedName!,
+                DisplayName = x.Name.DisplayName,
+                Description = x.Description
+            }).ToArray();
+        }
+
+
+        [KernelFunction("find_tags")]
+        [Description("Searches an Industrial App Store data source for tags (i.e. instruments or sensors) with names matching the provided filter on the data source with the specified identifier. The * character can be used in the name filter as a wildcard. The page parameter specifies the result page to return.")]
+        public async Task<IEnumerable<IasTagDescriptor>> FindTagsAsync(FindTagsRequest request, CancellationToken cancellationToken) {
+            var result = await _iasClient.DataSources.FindTagsAsync(request.DataSourceId, nameFilter: request.Name, page: request.Page, cancellationToken: cancellationToken);
+
+            return result.Select(x => new IasTagDescriptor() {
+                Name = x.Name,
+                Description = x.Description,
+                Units = x.UnitOfMeasure,
+                States = x.DigitalStates?.Count > 0
+                    ? x.DigitalStates.Select(s => new IasTagDiscreteState() { Name = s.Name, Value = s.Value }).ToArray()
+                    : null
+            }).ToArray();
+        }
+
+
+        [KernelFunction("read_current_values")]
+        [Description("Reads the current values of the specified tags.")]
+        public async Task<IEnumerable<IasDataValueCollection>> ReadCurrentValuesAsync(ReadCurrentValuesRequest request, CancellationToken cancellationToken) {
+            var result = await _iasClient.DataSources.ReadSnapshotTagValuesAsync(request.DataSourceId, request.TagNames, cancellationToken: cancellationToken);
+
+            return result!.Select(x => new IasDataValueCollection() {
+                TagName = x.Key,
+                Values = new[] {
+                    IasDataValue.FromTagValue(x.Value)
+                }
+            }).ToArray();
+        }
+
+
+        [KernelFunction("read_raw_historical_values")]
+        [Description("Reads raw historical values for the specified tags. Note that data for individual tags is unlikely to align exactly by timestamp due to the data filtering techniques applied when recording data.")]
+        public async Task<IEnumerable<IasDataValueCollection>> ReadRawHistoricalValuesAsync(ReadRawHistoricalValuesRequest request, CancellationToken cancellationToken) {
+            var result = await _iasClient.DataSources.ReadRawTagValuesAsync(request.DataSourceId, request.TagNames, request.StartTime, request.EndTime, request.MaxSamples, cancellationToken: cancellationToken);
+
+            return result!.Select(x => new IasDataValueCollection() {
+                TagName = x.Key,
+                Values = x.Value.Values.Select(x => IasDataValue.FromTagValue(x)).ToArray()
+            }).ToArray();
+        }
+
+
+        [KernelFunction("read_best_fit_historical_values")]
+        [Description("Reads a best-fit set of raw historical values for the specified tags for display purposes. This may also be referred to as a plot query. Note that data for individual tags is unlikely to align exactly by timestamp due to the data filtering techniques applied when recording data.")]
+        public async Task<IEnumerable<IasDataValueCollection>> ReadBestFitHistoricalValuesAsync(ReadBestFitHistoricalValuesRequest request, CancellationToken cancellationToken) {
+            var result = await _iasClient.DataSources.ReadPlotTagValuesAsync(request.DataSourceId, request.TagNames, request.StartTime, request.EndTime, request.Width, cancellationToken: cancellationToken);
+
+            return result!.Select(x => new IasDataValueCollection() {
+                TagName = x.Key,
+                Values = x.Value.Values.Select(x => IasDataValue.FromTagValue(x)).ToArray()
+            }).ToArray();
+        }
+
+
+        [KernelFunction("read_processed_historical_values")]
+        [Description("Reads aggregated historical values for the specified tags.")]
+        public async Task<IEnumerable<IasDataValueCollection>> ReadProcessedHistoricalValuesAsync(ReadProcessedHistoricalValuesRequest request, CancellationToken cancellationToken) {
+            var result = await _iasClient.DataSources.ReadProcessedTagValuesAsync(request.DataSourceId, request.TagNames, request.StartTime, request.EndTime, request.DataFunction, request.SampleInterval, cancellationToken: cancellationToken);
+
+            return result!.Select(x => new IasDataValueCollection() {
+                TagName = x.Key,
+                Values = x.Value.Values.Select(x => IasDataValue.FromTagValue(x)).ToArray()
+            }).ToArray();
+        }
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/PluginRequest.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/PluginRequest.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("A basic request to an Industrial App Store plugin.")]
+    public record PluginRequest {
+
+        [JsonPropertyName("reason")]
+        [Description("A SHORT (1-2 sentences max) plain text explanation for why the agent is calling the function.")]
+        public required string Reason { get; init; }
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/ReadBestFitHistoricalValuesRequest.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/ReadBestFitHistoricalValuesRequest.cs
@@ -1,0 +1,35 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Describes a request to read a best-fit of raw historical tag values for display in a chart.")]
+    public record ReadBestFitHistoricalValuesRequest : PluginRequest {
+
+        [JsonPropertyName("data_source_id")]
+        [Description("The ID of the Industrial App Store data source to query.")]
+        public required string DataSourceId { get; init; }
+
+        [JsonPropertyName("tag_names")]
+        [Description("The names of the tags to query.")]
+        [MinLength(1)]
+        [MaxLength(20)]
+        public required string[] TagNames { get; init; }
+
+        [JsonPropertyName("start_time")]
+        [Description("The absolute or relative start time for the query.")]
+        public required string StartTime { get; init; }
+
+        [JsonPropertyName("end_time")]
+        [Description("The absolute or relative end time for the query.")]
+        public required string EndTime { get; init; }
+
+        [JsonPropertyName("width")]
+        [Description("The expected pixel width of the chart. A higher number will result in more samples being selected.")]
+        [Range(1, 5000)]
+        public int Width { get; init; } = 2000;
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/ReadCurrentValuesRequest.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/ReadCurrentValuesRequest.cs
@@ -1,0 +1,22 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Describes a request to read current tag values.")]
+    public record ReadCurrentValuesRequest : PluginRequest {
+
+        [JsonPropertyName("data_source_id")]
+        [Description("The ID of the Industrial App Store data source to query.")]
+        public required string DataSourceId { get; init; }
+
+        [JsonPropertyName("tag_names")]
+        [Description("The names of the tags to query.")]
+        [MinLength(1)]
+        [MaxLength(100)]
+        public required string[] TagNames { get; init; }
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/ReadProcessedHistoricalValuesRequest.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/ReadProcessedHistoricalValuesRequest.cs
@@ -1,0 +1,38 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Describes a request to read processed/aggregated historical tag values.")]
+    public record ReadProcessedHistoricalValuesRequest : PluginRequest {
+
+        [JsonPropertyName("data_source_id")]
+        [Description("The ID of the Industrial App Store data source to query.")]
+        public required string DataSourceId { get; init; }
+
+        [JsonPropertyName("tag_names")]
+        [Description("The names of the tags to query.")]
+        [MinLength(1)]
+        [MaxLength(20)]
+        public required string[] TagNames { get; init; }
+
+        [JsonPropertyName("start_time")]
+        [Description("The absolute or relative start time for the query.")]
+        public required string StartTime { get; init; }
+
+        [JsonPropertyName("end_time")]
+        [Description("The absolute or relative end time for the query.")]
+        public required string EndTime { get; init; }
+
+        [JsonPropertyName("data_function")]
+        [Description("The aggregate function to use. Different data sources support different functions but commonly-supported functions include INTERP (interpolated), AVG (average), MIN (minimum) and MAX (maximum).")]
+        public required string DataFunction { get; init; }
+
+        [JsonPropertyName("sample_interval")]
+        [Description("The sample interval to perform the aggregation over. Note that ISO 8601 time periods are *not* supported.")]
+        public required string SampleInterval { get; init; }
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/ReadRawHistoricalValuesRequest.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/Plugins/ReadRawHistoricalValuesRequest.cs
@@ -1,0 +1,35 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace IntelligentPlant.IndustrialAppStore.SemanticKernel.Plugins {
+
+    [Description("Describes a request to read raw historical tag values.")]
+    public record ReadRawHistoricalValuesRequest : PluginRequest {
+
+        [JsonPropertyName("data_source_id")]
+        [Description("The ID of the Industrial App Store data source to query.")]
+        public required string DataSourceId { get; init; }
+
+        [JsonPropertyName("tag_names")]
+        [Description("The names of the tags to query.")]
+        [MinLength(1)]
+        [MaxLength(20)]
+        public required string[] TagNames { get; init; }
+
+        [JsonPropertyName("start_time")]
+        [Description("The absolute or relative start time for the query.")]
+        public required string StartTime { get; init; }
+
+        [JsonPropertyName("end_time")]
+        [Description("The absolute or relative end time for the query.")]
+        public required string EndTime { get; init; }
+
+        [JsonPropertyName("max_samples")]
+        [Description("The maximum number of samples to retrieve per tag.")]
+        [Range(1, 5000)]
+        public int MaxSamples { get; init; } = 5000;
+
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.SemanticKernel/README.md
@@ -1,0 +1,75 @@
+# IntelligentPlant.IndustrialAppStore.SemanticKernel
+
+This package contains extensions for the .NET version of [Semantic Kernel](https://learn.microsoft.com/en-us/semantic-kernel/overview/) to allow tool-trained AI models to query the Industrial App Store.
+
+> [!WARNING]
+> This package is experimental and is intended for building proof of concept AI applications. Features may change or be removed in future releases.
+
+
+# Getting Started
+
+You can register core Semantic Kernel services via the `IIndustrialAppStoreBuilder` type:
+
+```csharp
+// You must explicitly suppress the experimental warning to acknowledge 
+// that you understand the limits of using this package.
+#pragma warning disable IASSK0001
+
+builder.Services.AddIndustrialAppStoreApiServices()
+    .AddSemanticKernelServices();
+```
+
+This will register a scoped `Kernel` service that can be used to interact with AI pipelines. The kernel is pre-configured with plugins that allow AI tools such as tool-trained large language models (LLMs) to query the Industrial App Store Data API.
+
+> [!NOTE]
+> You must register Semantic Kernel AI services such as `IChatCompletionService` yourself. This package does not include any specific AI services, as the choice of AI service is dependent on your application and the models you wish to use.
+
+
+# Using a Chat Service
+
+Refer to the [Microsoft documentation](https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion) about how to register a chat service with the Semantic Kernel.
+
+Once you have registered your chat service and have configured the Industrial App Store API services so that the client can obtain a valid access token, you can use your `Kernel` service to start a chat session. For example:
+
+```csharp
+var kernel = scope.ServiceProvider.GetRequiredService<Kernel>();
+var chatCompletionService = kernel.GetRequiredService<IChatCompletionService>();
+
+#pragma warning disable IASSK0001
+
+// Create a new chat history and add a system prompt that helps the AI 
+// understand how to use the Industrial App Store plugins.
+var chatHistory = new ChatHistory()
+    .AddIndustrialAppStoreSystemPrompt();
+
+chatHistory.AddUserMessage("List my Industrial App Store data sources.");
+
+var response = chatCompletionService.GetStreamingChatMessageContentsAsync(
+    chatHistory: chatHistory,
+    kernel: kernel,
+    cancellationToken: cancellationToken);
+
+await foreach (var chunk in response) {
+    Console.Write(chunk.Content ?? Environment.NewLine);
+}
+```
+
+
+## Managing Chat History
+
+When you use a `ChatHistory` object with an `IChatCompletionService` it is **your responsibility** to add the messages returned by the assistant to the history, so that they can be included in the context for subsequent requests. You must also ensure that the context does not grow too large. Semantic Kernel provides services that can perform [chat history reduction](https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion/chat-history#chat-history-reduction) to truncate or summarise earlier messages in the chat history to ensure that the context remains manageable.
+
+
+## Working with Reasoning Models
+
+Tool-trained reasoning models such as [QwQ](https://huggingface.co/Qwen/QwQ-32B) are capable of planning and executing a sequence of steps to achieve a goal. For example, you can ask the model questions such as *"What is the current temperature of Sensor-1 on my Edge Historian?"* and it will use multiple tool calls to retrieve available data sources, find the correct tag name, and then request the current value of the tag.
+
+> [!TIP]
+> When maintaining a `ChatHistory` when working with a reasoning model, you usually need to filter out the part of the response that contains the reasoning steps to ensure that the context for subsequent messages does not become unnecessarily large. Identifying reasoning steps may vary depending on the model that you are using. In the case of QwQ, the reasoning steps are usually encloded in `<think>...</think>` tags, so any part of the response inside these tags should be removed prior to adding the assistant response to the `ChatHistory`.
+
+
+# Additional Notes
+
+When registering Industrial App Store-related services, most services are registered with a scoped lifetime (for example, to allow the IAS API client to use an access token associated with the calling user in an ASP.NET Core application). As a result, some of the Semantic Kernel-related services registered by this package (including the `Kernel` service itself) are also registered with a scoped lifetime.
+
+When using the `Kernel` service, ensure that you create a new scope for the session if one has not already been created. This is typically only required in non-ASP.NET Core applications, such as console applications or background services.


### PR DESCRIPTION
This PR adds a new experimental project that contains a plugin for Microsoft's [Semantic Kernel](https://learn.microsoft.com/en-us/semantic-kernel/overview/) that allows tool-trained LLMs to make calls to the Industrial App Store Data APIs.

When using a tool-trained reasoning model (such as [QwQ](https://huggingface.co/Qwen/QwQ-32B)), the model can use tools in multiple steps to answer queries. For example, if your prompt is *"Get the current value of the temperature for Sensor-1 in my Edge Historian data source"*, the model will typically make a call to get available data sources, then perform a tag search on the data source it identifies as Edge Historian, and then request the current value of the temperature tag that it thinks you were referring to.

> [!IMPORTANT]
> Using these extensions requires an explicit suppression of a diagnostic code in the consuming code or project (e.g. via a `#pragma` directive) to acknowledge that these extensions are experimental and make change or be removed in the future.