### PR TITLE
Suppress token decryption errors in CLI tools

### DIFF
--- a/samples/ExampleCliApplication/Program.cs
+++ b/samples/ExampleCliApplication/Program.cs
@@ -1,5 +1,5 @@
-﻿using IntelligentPlant.IndustrialAppStore.CommandLine;
-using IntelligentPlant.IndustrialAppStore.Client;
+﻿using IntelligentPlant.IndustrialAppStore.Client;
+using IntelligentPlant.IndustrialAppStore.CommandLine;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/samples/ExampleCliApplication/Program.cs
+++ b/samples/ExampleCliApplication/Program.cs
@@ -1,6 +1,7 @@
 ﻿using IntelligentPlant.IndustrialAppStore.Client;
 using IntelligentPlant.IndustrialAppStore.CommandLine;
 
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -13,6 +14,11 @@ var configuration = new ConfigurationBuilder()
 var services = new ServiceCollection();
 
 services.AddIndustrialAppStoreCliServices(options => configuration.GetSection("IAS").Bind(options));
+
+// Set the application name for the Data Protection system. This is used to isolate protected data
+// specific to this application.
+services.AddDataProtection()
+    .SetApplicationName("ExampleCliApplication");
 
 var provider = services.BuildServiceProvider();
 

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/PACKAGE_README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/PACKAGE_README.md
@@ -52,3 +52,18 @@ var myDataDir = appDataDir.CreateSubdirectory("MyData");
 ```
 
 Encrypted authentication tokens are saved to a sub-folder of the base folder provided by `AppDataFolderProvider`.
+
+
+## Specifying an Application Discriminator for Encryption
+
+The `IndustrialAppStoreSessionManager` type uses [ASP.NET Core Data Protection](https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/introduction) to encrypt authentication tokens at rest. When using Microsoft.Extensions.Hosting, the application discriminator for the data protection system (used to isolate protected data even when apps share the same keys) is derived from the content root path for the host by default. 
+
+The content root path defaults to the directory containing the application assembly. This means that if you run multiple instances of your app from different directories, they will not be able to decrypt each other's tokens. If you want to share tokens between different instances of your app regardless of the content root path, you can configure the application name to use with the data protection system:
+
+```csharp
+builder.Services
+    .AddDataProtection()
+    .SetApplicationName("MyIasApp");
+```
+
+If you are not using Microsoft.Extensions.Hosting and are instead manually creating an `IServiceCollection`, no application discriminator is set by default. You should set an application name for your app as shown above to ensure that the data protection system isolates protected data specific to your application.

--- a/src/IntelligentPlant.IndustrialAppStore.CommandLine/README.md
+++ b/src/IntelligentPlant.IndustrialAppStore.CommandLine/README.md
@@ -55,3 +55,18 @@ var myDataDir = appDataDir.CreateSubdirectory("MyData");
 ```
 
 Encrypted authentication tokens are saved to a sub-folder of the base folder provided by `AppDataFolderProvider`.
+
+
+## Specifying an Application Discriminator for Encryption
+
+The `IndustrialAppStoreSessionManager` type uses [ASP.NET Core Data Protection](https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/introduction) to encrypt authentication tokens at rest. When using Microsoft.Extensions.Hosting, the application discriminator for the data protection system (used to isolate protected data even when apps share the same keys) is derived from the content root path for the host by default. 
+
+The content root path defaults to the directory containing the application assembly. This means that if you run multiple instances of your app from different directories, they will not be able to decrypt each other's tokens. If you want to share tokens between different instances of your app regardless of the content root path, you can configure the application name to use with the data protection system:
+
+```csharp
+builder.Services
+    .AddDataProtection()
+    .SetApplicationName("MyIasApp");
+```
+
+If you are not using Microsoft.Extensions.Hosting and are instead manually creating an `IServiceCollection`, no application discriminator is set by default. You should set an application name for your app as shown above to ensure that the data protection system isolates protected data specific to your application.


### PR DESCRIPTION
This PR ensures that errors that occur when `IndustrialAppStoreSessionManager` attempts to load or decrypt an authentication session do not bubble out of the class. Instead, errors are logged and the session manager treats the error as if no session was present.

Additionally, the example CLI application (and therefor the CLI app project template) has been updated to specify an application discriminator for the data protection system, and the readme files for the CLI tool have been modified to include information about setting application discriminators.