### PR TITLE
Improve handling of 400 responses when using refresh tokens

### DIFF
--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/AuthenticationPropertiesTokenStore.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/AuthenticationPropertiesTokenStore.cs
@@ -1,6 +1,7 @@
 ﻿using System.Globalization;
 
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace IntelligentPlant.IndustrialAppStore.Authentication {
@@ -29,11 +30,15 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         /// <param name="timeProvider">
         ///   The time provider.
         /// </param>
+        /// <param name="logger">
+        ///   The logger for the token store.
+        /// </param>
         public AuthenticationPropertiesTokenStore(
             IOptions<IndustrialAppStoreAuthenticationOptions> options, 
             HttpClient httpClient,
-            TimeProvider timeProvider
-        ) : base(options, httpClient, timeProvider) { }
+            TimeProvider timeProvider,
+            ILogger<AuthenticationPropertiesTokenStore> logger
+        ) : base(options, httpClient, timeProvider, logger) { }
 
 
         /// <summary>


### PR DESCRIPTION
Fixes #107.

400 responses when using refresh tokens are now logged and cause the token store to assume that the user does not have a valid access token instead of allowing the exception to propagate.

Other exceptions propagate as before.