### PR TITLE
Mitigation for CVE-2025-55247

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,14 +9,15 @@
     <PackageVersion Include="IntelligentPlant.Relativity" Version="3.0.0" />
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="3.0.1" />
     <PackageVersion Include="Jaahas.OpenTelemetry.Extensions" Version="3.0.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.15" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.15" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.15" />
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="8.0.21" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.21" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.21" />
     <PackageVersion Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Build" Version="17.8.43" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.15" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.21" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
@@ -29,7 +30,7 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageVersion Include="OpenTelemetry" Version="1.12.0" />
     <PackageVersion Include="OpenTelemetry.Api" Version="1.12.0" />
@@ -42,6 +43,6 @@
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Net.Http.Json" Version="8.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 </Project>

--- a/samples/CustomTokenStoreExample/CustomTokenStoreExample.csproj
+++ b/samples/CustomTokenStoreExample/CustomTokenStoreExample.csproj
@@ -24,6 +24,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
+    <!-- Remove Microsoft.Build reference once a version of Microsoft.VisualStudio.Web.CodeGeneration.Design that mitigates CVE-2025-55247 is available. -->
+    <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" />

--- a/samples/ExampleMvcApplication/ExampleMvcApplication.csproj
+++ b/samples/ExampleMvcApplication/ExampleMvcApplication.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="Jaahas.OpenTelemetry.Extensions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
+    <!-- Remove Microsoft.Build reference once a version of Microsoft.VisualStudio.Web.CodeGeneration.Design that mitigates CVE-2025-55247 is available. -->
+    <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" />
     <PackageReference Include="OpenTelemetry" />


### PR DESCRIPTION
Adds mitigation for [CVE-2025-55247](https://github.com/dotnet/announcements/issues/370).

We inherit `Microsoft.Build` as a transitive reference in two projects, via a top-level package reference to [Microsoft.VisualStudio.Web.CodeGeneration.Design](https://www.nuget.org/packages/Microsoft.VisualStudio.Web.CodeGeneration.Design). At time of writing there is not an updated version of this package available that mitigates the transitive vulnerability, so the PR adds a top-level reference to `Microsoft.Build` to the affected projects.