### PR TITLE
Add support for calling adapter toolkit custom functions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     <NoWarn>NU1507;$(NoWarn)</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="IntelligentPlant.AppStoreConnect.Adapter.Core" Version="6.0.0-pre.1552" />
     <PackageVersion Include="IntelligentPlant.ProblemDetails.Core" Version="4.0.0" />
     <PackageVersion Include="IntelligentPlant.Relativity" Version="3.0.0" />
     <PackageVersion Include="Jaahas.HttpRequestTransformer" Version="3.0.1" />
@@ -42,7 +43,7 @@
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Net.Http.Json" Version="8.0.1" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.6" />
+    <PackageVersion Include="System.Net.Http.Json" Version="10.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
   </ItemGroup>
 </Project>

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/AdaptersClient.CustomFunctions.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/AdaptersClient.CustomFunctions.cs
@@ -1,0 +1,132 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Net.Http.Json;
+
+using DataCore.Adapter.Extensions;
+
+namespace IntelligentPlant.DataCore.Client.Clients {
+
+    partial class AdaptersClient {
+
+        /// <summary>
+        /// Client for App Store Connect adapter custom functions.
+        /// </summary>
+        public class CustomFunctionsClient {
+
+            private readonly AdaptersClient _client;
+
+
+            internal CustomFunctionsClient(AdaptersClient client) {
+                _client = client;
+            }
+
+
+            /// <summary>
+            /// Gets the custom functions exposed by the specified driver.
+            /// </summary>
+            /// <param name="adapterId">
+            ///   The adapter ID.
+            /// </param>
+            /// <param name="cancellationToken">
+            ///   The cancellation token for the operation.
+            /// </param>
+            /// <returns>
+            ///   The custom functions exposed by the specified adapter.
+            /// </returns>
+            /// <exception cref="ArgumentException">
+            ///   <paramref name="adapterId"/> is <see langword="null"/> or white space.
+            /// </exception>
+            public async Task<IEnumerable<CustomFunctionDescriptor>> GetCustomFunctionsAsync(string adapterId, CancellationToken cancellationToken) {
+                if (string.IsNullOrWhiteSpace(adapterId)) {
+                    throw new ArgumentException(Resources.Error_DriverIdIsRequired, nameof(adapterId));
+                }
+
+                var url = _client.GetAbsoluteUrl($"api/rpc/v2/{Uri.EscapeDataString(adapterId)}/functions");
+
+                using var response = await _client.HttpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+                await response.ThrowOnErrorResponse().ConfigureAwait(false);
+
+                return await response.Content.ReadFromJsonAsync<IEnumerable<CustomFunctionDescriptor>>(_client.Options.JsonOptions, cancellationToken).ConfigureAwait(false) ?? Array.Empty<CustomFunctionDescriptor>();
+            }
+
+
+            /// <summary>
+            /// Gets detailed information about a custom function.
+            /// </summary>
+            /// <param name="adapterId">
+            ///   The adapter ID.
+            /// </param>
+            /// <param name="functionId">
+            ///   The custom function ID.
+            /// </param>
+            /// <param name="cancellationToken">
+            ///   The cancellation token for the operation.
+            /// </param>
+            /// <returns>
+            ///   The custom function details, or <see langword="null"/> if the function could not be found.
+            /// </returns>
+            /// <exception cref="ArgumentException">
+            ///   <paramref name="adapterId"/> is <see langword="null"/> or white space.
+            /// </exception>
+            /// <exception cref="ArgumentNullException">
+            ///   <paramref name="functionId"/> is <see langword="null"/>.
+            /// </exception>
+            public async Task<CustomFunctionDescriptorExtended?> GetCustomFunctionAsync(string adapterId, Uri functionId, CancellationToken cancellationToken) {
+                if (string.IsNullOrWhiteSpace(adapterId)) {
+                    throw new ArgumentException(Resources.Error_DriverIdIsRequired, nameof(adapterId));
+                }
+                if (functionId == null) {
+                    throw new ArgumentNullException(nameof(functionId));
+                }
+
+                var url = _client.GetAbsoluteUrl($"api/rpc/v2/{Uri.EscapeDataString(adapterId)}/functions/details?id={Uri.EscapeDataString(functionId.ToString())}");
+                using var response = await _client.HttpClient.GetAsync(url, cancellationToken).ConfigureAwait(false);
+                await response.ThrowOnErrorResponse().ConfigureAwait(false);
+                return await response.Content.ReadFromJsonAsync<CustomFunctionDescriptorExtended>(_client.Options.JsonOptions, cancellationToken).ConfigureAwait(false);
+            }
+
+
+            /// <summary>
+            /// Invokes a custom function.
+            /// </summary>
+            /// <param name="adapterId">
+            ///   The adapter ID.
+            /// </param>
+            /// <param name="request">
+            ///   The custom function invocation request.
+            /// </param>
+            /// <param name="cancellationToken">
+            ///   The cancellation token for the operation.
+            /// </param>
+            /// <returns>
+            ///   The custom function invocation response.
+            /// </returns>
+            /// <exception cref="ArgumentException">
+            ///   <paramref name="adapterId"/> is <see langword="null"/> or white space.
+            /// </exception>
+            /// <exception cref="ArgumentNullException">
+            ///   <paramref name="request"/> is <see langword="null"/>.
+            /// </exception>
+            /// <exception cref="ValidationException">
+            ///   <paramref name="request"/> fails validation.
+            /// </exception>
+            public async Task<CustomFunctionInvocationResponse> InvokeCustomFunctionAsync(string adapterId, CustomFunctionInvocationRequest request, CancellationToken cancellationToken) {
+                if (string.IsNullOrWhiteSpace(adapterId)) {
+                    throw new ArgumentException(Resources.Error_DriverIdIsRequired, nameof(adapterId));
+                }
+                if (request == null) {
+                    throw new ArgumentNullException(nameof(request));
+                }
+
+                Validator.ValidateObject(request, new ValidationContext(request), true);
+
+                var url = _client.GetAbsoluteUrl($"api/rpc/v2/{Uri.EscapeDataString(adapterId)}/functions/invoke");
+                using var response = await _client.HttpClient.PostAsJsonAsync(url, request, _client.Options.JsonOptions, cancellationToken).ConfigureAwait(false);
+                await response.ThrowOnErrorResponse().ConfigureAwait(false);
+                var result = await response.Content.ReadFromJsonAsync<CustomFunctionInvocationResponse>(_client.Options.JsonOptions, cancellationToken).ConfigureAwait(false);
+                return result!;
+            }
+
+        }
+
+    }
+}

--- a/src/IntelligentPlant.DataCore.HttpClient/Clients/AdaptersClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Clients/AdaptersClient.cs
@@ -1,0 +1,23 @@
+﻿namespace IntelligentPlant.DataCore.Client.Clients {
+
+    /// <summary>
+    /// Client for querying the App Store Connect adapters.
+    /// </summary>
+    /// <remarks>
+    ///   App Store Connect adapters are next-generation data connectors for the Industrial App Store Data API.
+    /// </remarks>
+    public sealed partial class AdaptersClient : ClientBase {
+
+        /// <summary>
+        /// The adapter custom functions client.
+        /// </summary>
+        public CustomFunctionsClient CustomFunctions { get; }
+
+        
+        internal AdaptersClient(HttpClient httpClient, DataCoreHttpClientOptions options) : base(httpClient, options) { 
+            CustomFunctions = new CustomFunctionsClient(this);
+        }
+
+    }
+
+}

--- a/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClient.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/DataCoreHttpClient.cs
@@ -24,6 +24,11 @@ namespace IntelligentPlant.DataCore.Client {
         protected DataCoreHttpClientOptions Options { get; }
 
         /// <summary>
+        /// The App Store Connect adapters client.
+        /// </summary>
+        public AdaptersClient Adapters { get; }
+
+        /// <summary>
         /// The asset model client.
         /// </summary>
         public AssetModelClient AssetModel { get; }
@@ -83,6 +88,7 @@ namespace IntelligentPlant.DataCore.Client {
                 ? Options.DataCoreUrl
                 : new Uri(Options.DataCoreUrl.ToString() + "/");
 
+            Adapters = new AdaptersClient(HttpClient, Options);
             AssetModel = new AssetModelClient(HttpClient, Options);
             Info = new InfoClient(HttpClient, Options);
             DataSources = new DataSourcesClient(HttpClient, Options);

--- a/src/IntelligentPlant.DataCore.HttpClient/IntelligentPlant.DataCore.HttpClient.csproj
+++ b/src/IntelligentPlant.DataCore.HttpClient/IntelligentPlant.DataCore.HttpClient.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="IntelligentPlant.AppStoreConnect.Adapter.Core" />
     <PackageReference Include="IntelligentPlant.ProblemDetails.Core" />
     <PackageReference Include="IntelligentPlant.Relativity" />
     <PackageReference Include="Jaahas.HttpRequestTransformer" />

--- a/src/IntelligentPlant.DataCore.HttpClient/Model/DataSourceDriverFeatures.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Model/DataSourceDriverFeatures.cs
@@ -96,6 +96,14 @@ namespace IntelligentPlant.DataCore.Client.Model {
         /// The driver supports scripting.
         /// </summary>
         [Description("The driver supports scripting.")]
-        Scripting = 8192
+        Scripting = 8192,
+
+        /// <summary>
+        /// The driver supports App Store Connect adapter-style custom functions.
+        /// </summary>
+        /// <seealso href="https://github.com/intelligentplant/AppStoreConnect.Adapters"/>
+        [Description("The driver supports App Store Connect adapter-style custom functions.")]
+        AdapterCustomFunctions = 16384
+
     }
 }

--- a/src/IntelligentPlant.DataCore.HttpClient/Resources.Designer.cs
+++ b/src/IntelligentPlant.DataCore.HttpClient/Resources.Designer.cs
@@ -88,6 +88,15 @@ namespace IntelligentPlant.DataCore.Client {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A driver ID is required..
+        /// </summary>
+        internal static string Error_DriverIdIsRequired {
+            get {
+                return ResourceManager.GetString("Error_DriverIdIsRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An event sink name is required..
         /// </summary>
         internal static string Error_EventSinkNameIsRequired {

--- a/src/IntelligentPlant.DataCore.HttpClient/Resources.resx
+++ b/src/IntelligentPlant.DataCore.HttpClient/Resources.resx
@@ -130,6 +130,9 @@
 {2} - status code
 {3} - reason phrase</comment>
   </data>
+  <data name="Error_DriverIdIsRequired" xml:space="preserve">
+    <value>A driver ID is required.</value>
+  </data>
   <data name="Error_EventSinkNameIsRequired" xml:space="preserve">
     <value>An event sink name is required.</value>
   </data>


### PR DESCRIPTION
The next release of the Industrial App Store Data API adds support for invoking custom functions on drivers that implement the App Store Connect adapter toolkit custom functions feature.

Adapter toolkit custom functions offer several improvements over "classic" custom functions currently used by some drivers, including:

- **Discoverability:** The new APIs allow information about available custom functions to be requested programatically.
- **Flexibility:** Adapter toolkit custom functions use JSON Schemas to describe their request and response models, which gives flexibility in how inputs and outputs can be structured and validated, and also makes it easier to write strongly-typed extensions for invoking custom functions.