### PR TITLE
Disable retry timeout in IAS API Client (IndustrialAppStoreHttpClient) resilience handler

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,5 +45,9 @@
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Net.Http.Json" Version="10.0.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
+    <!-- Test packages -->
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
   </ItemGroup>
 </Project>

--- a/IntelligentPlant.IndustrialAppStore.ClientTools.sln
+++ b/IntelligentPlant.IndustrialAppStore.ClientTools.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -68,6 +68,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntelligentPlant.Industrial
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelligentPlant.IndustrialAppStore.SemanticKernel", "src\IntelligentPlant.IndustrialAppStore.SemanticKernel\IntelligentPlant.IndustrialAppStore.SemanticKernel.csproj", "{43D9E2E5-2EAC-40AB-BDAB-747E26082551}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntelligentPlant.IndustrialAppStore.Authentication.Tests", "src\IntelligentPlant.IndustrialAppStore.Authentication.Tests\IntelligentPlant.IndustrialAppStore.Authentication.Tests.csproj", "{952ECEAF-1234-4EF1-9A7D-A744E3434873}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -118,6 +120,10 @@ Global
 		{43D9E2E5-2EAC-40AB-BDAB-747E26082551}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43D9E2E5-2EAC-40AB-BDAB-747E26082551}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{43D9E2E5-2EAC-40AB-BDAB-747E26082551}.Release|Any CPU.Build.0 = Release|Any CPU
+		{952ECEAF-1234-4EF1-9A7D-A744E3434873}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{952ECEAF-1234-4EF1-9A7D-A744E3434873}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{952ECEAF-1234-4EF1-9A7D-A744E3434873}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{952ECEAF-1234-4EF1-9A7D-A744E3434873}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -135,6 +141,7 @@ Global
 		{D2CB5AD0-64F8-4691-9BD3-A8E0719AE046} = {65FE3E10-29B7-4A78-9ED8-C8384AE9D420}
 		{C8844839-3EA9-4CDD-AF2C-09B0B36AF60D} = {49E8C063-F41F-451F-81BF-C4960B9A0168}
 		{43D9E2E5-2EAC-40AB-BDAB-747E26082551} = {49E8C063-F41F-451F-81BF-C4960B9A0168}
+		{952ECEAF-1234-4EF1-9A7D-A744E3434873} = {49E8C063-F41F-451F-81BF-C4960B9A0168}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D12472DA-7354-4A19-8F60-4F9D42C71241}

--- a/samples/CustomTokenStoreExample/libman.json
+++ b/samples/CustomTokenStoreExample/libman.json
@@ -53,6 +53,7 @@
       ]
     },
     {
+      "provider": "unpkg",
       "library": "rxjs@7.5.4",
       "destination": "wwwroot/lib/rxjs/",
       "files": [

--- a/samples/ExampleMvcApplication/libman.json
+++ b/samples/ExampleMvcApplication/libman.json
@@ -62,7 +62,7 @@
       ]
     },
     {
-      "provider": "cdnjs",
+      "provider": "unpkg",
       "library": "rxjs@7.8.1",
       "destination": "wwwroot/lib/rxjs/",
       "files": [

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/ClaimsPrincipalExtensionsTests.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/ClaimsPrincipalExtensionsTests.cs
@@ -1,0 +1,78 @@
+using System.Security.Claims;
+
+namespace IntelligentPlant.IndustrialAppStore.Authentication.Tests;
+
+public class ClaimsPrincipalExtensionsTests {
+
+    private static ClaimsPrincipal PrincipalWith(params (string Type, string Value)[] claims) {
+        var identity = new ClaimsIdentity(claims.Select(c => new Claim(c.Type, c.Value)));
+        return new ClaimsPrincipal(identity);
+    }
+
+    [Fact]
+    public void GetUserId_ReturnsNameIdentifierClaim() {
+        var principal = PrincipalWith((ClaimTypes.NameIdentifier, "user-123"));
+        Assert.Equal("user-123", principal.GetUserId());
+    }
+
+    [Fact]
+    public void GetUserId_ReturnsNull_WhenClaimAbsent() {
+        Assert.Null(new ClaimsPrincipal().GetUserId());
+    }
+
+    [Fact]
+    public void GetUserName_ReturnsNameClaim() {
+        var principal = PrincipalWith((ClaimTypes.Name, "Jane Smith"));
+        Assert.Equal("Jane Smith", principal.GetUserName());
+    }
+
+    [Fact]
+    public void GetUserName_ReturnsNull_WhenClaimAbsent() {
+        Assert.Null(new ClaimsPrincipal().GetUserName());
+    }
+
+    [Fact]
+    public void GetOrganisationName_ReturnsOrgNameClaim() {
+        var principal = PrincipalWith((IndustrialAppStoreAuthenticationDefaults.OrgNameClaimType, "Acme Corp"));
+        Assert.Equal("Acme Corp", principal.GetOrganisationName());
+    }
+
+    [Fact]
+    public void GetOrganisationName_ReturnsNull_WhenClaimAbsent() {
+        Assert.Null(new ClaimsPrincipal().GetOrganisationName());
+    }
+
+    [Fact]
+    public void GetOrganisationId_ReturnsOrgIdClaim() {
+        var principal = PrincipalWith((IndustrialAppStoreAuthenticationDefaults.OrgIdentifierClaimType, "org-456"));
+        Assert.Equal("org-456", principal.GetOrganisationId());
+    }
+
+    [Fact]
+    public void GetOrganisationId_ReturnsNull_WhenClaimAbsent() {
+        Assert.Null(new ClaimsPrincipal().GetOrganisationId());
+    }
+
+    [Fact]
+    public void GetProfilePictureUrl_ReturnsPictureClaim() {
+        var principal = PrincipalWith((IndustrialAppStoreAuthenticationDefaults.PictureClaimType, "https://example.com/pic.jpg"));
+        Assert.Equal("https://example.com/pic.jpg", principal.GetProfilePictureUrl());
+    }
+
+    [Fact]
+    public void GetProfilePictureUrl_ReturnsNull_WhenClaimAbsent() {
+        Assert.Null(new ClaimsPrincipal().GetProfilePictureUrl());
+    }
+
+    [Fact]
+    public void GetSessionId_ReturnsSessionIdClaim() {
+        var principal = PrincipalWith((IndustrialAppStoreAuthenticationDefaults.AppSessionIdClaimType, "sess-abc"));
+        Assert.Equal("sess-abc", principal.GetSessionId());
+    }
+
+    [Fact]
+    public void GetSessionId_ReturnsNull_WhenClaimAbsent() {
+        Assert.Null(new ClaimsPrincipal().GetSessionId());
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/IntelligentPlant.IndustrialAppStore.Authentication.Tests.csproj
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/IntelligentPlant.IndustrialAppStore.Authentication.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <SignOutput>false</SignOutput>
+    <IncludeDevelopmentPackages>false</IncludeDevelopmentPackages>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IntelligentPlant.IndustrialAppStore.Authentication\IntelligentPlant.IndustrialAppStore.Authentication.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/OAuthTokensTests.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/OAuthTokensTests.cs
@@ -1,0 +1,39 @@
+namespace IntelligentPlant.IndustrialAppStore.Authentication.Tests;
+
+public class OAuthTokensTests {
+
+    [Fact]
+    public void Constructor_SetsAllProperties() {
+        var expiry = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var tokens = new OAuthTokens("Bearer", "access-token", "refresh-token", expiry);
+
+        Assert.Equal("Bearer", tokens.TokenType);
+        Assert.Equal("access-token", tokens.AccessToken);
+        Assert.Equal("refresh-token", tokens.RefreshToken);
+        Assert.Equal(expiry, tokens.UtcExpiresAt);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsForNullAccessToken() {
+        Assert.Throws<ArgumentNullException>(() => new OAuthTokens("Bearer", null!, null, null));
+    }
+
+    [Fact]
+    public void Constructor_AllowsNullRefreshToken() {
+        var tokens = new OAuthTokens("Bearer", "access-token", null, null);
+        Assert.Null(tokens.RefreshToken);
+    }
+
+    [Fact]
+    public void Constructor_AllowsNullExpiry() {
+        var tokens = new OAuthTokens("Bearer", "access-token", null, null);
+        Assert.Null(tokens.UtcExpiresAt);
+    }
+
+    [Fact]
+    public void Constructor_AllowsNullTokenType() {
+        var tokens = new OAuthTokens(null!, "access-token", null, null);
+        Assert.Null(tokens.TokenType);
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/ResilienceConfigurationTests.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/ResilienceConfigurationTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace IntelligentPlant.IndustrialAppStore.Authentication.Tests;
+
+public class ResilienceConfigurationTests {
+
+    [Fact]
+    public void ResiliencePipeline_CanBeBuilt_WithoutErrors() {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddIndustrialAppStoreAuthentication(options => {
+            options.ClientId = "test-client";
+        });
+
+        using var provider = services.BuildServiceProvider();
+
+        // CreateHandler is where the resilience pipeline is constructed and validated.
+        var handlerFactory = provider.GetRequiredService<IHttpMessageHandlerFactory>();
+
+        var ex = Record.Exception(() => handlerFactory.CreateHandler("IndustrialAppStoreHttpClient"));
+
+        Assert.Null(ex);
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/TestHelpers.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/TestHelpers.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace IntelligentPlant.IndustrialAppStore.Authentication.Tests;
+
+/// <summary>
+/// A TimeProvider that returns a fixed UTC time, allowing deterministic expiry tests.
+/// </summary>
+internal sealed class FixedTimeProvider : TimeProvider {
+    private readonly DateTimeOffset _utcNow;
+    public FixedTimeProvider(DateTimeOffset utcNow) => _utcNow = utcNow;
+    public override DateTimeOffset GetUtcNow() => _utcNow;
+}
+
+
+/// <summary>
+/// A concrete TokenStore for exercising the abstract base class logic.
+/// Token state is set via SetTokens() before calling GetTokensAsync().
+/// </summary>
+internal sealed class TestTokenStore : TokenStore {
+    private OAuthTokens? _tokens;
+
+    public TestTokenStore(
+        IOptions<IndustrialAppStoreAuthenticationOptions> options,
+        HttpClient httpClient,
+        TimeProvider timeProvider
+    ) : base(options, httpClient, timeProvider) { }
+
+    public void SetTokens(OAuthTokens? tokens) => _tokens = tokens;
+
+    protected override ValueTask InitAsync() => default;
+
+    protected override ValueTask<OAuthTokens?> GetTokensAsync() => new(_tokens);
+
+    protected override ValueTask SaveTokensAsync(OAuthTokens tokens) {
+        _tokens = tokens;
+        return default;
+    }
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/TokenStoreExtensionsTests.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/TokenStoreExtensionsTests.cs
@@ -1,0 +1,51 @@
+using static Microsoft.Extensions.Options.Options;
+
+namespace IntelligentPlant.IndustrialAppStore.Authentication.Tests;
+
+public class TokenStoreExtensionsTests {
+
+    private static async Task<TestTokenStore> InitializedStore(OAuthTokens? token = null) {
+        var options = Create(new IndustrialAppStoreAuthenticationOptions { ClientId = "test-client" });
+        var store = new TestTokenStore(options, new HttpClient(), TimeProvider.System);
+        if (token.HasValue) {
+            store.SetTokens(token.Value);
+        }
+        await ((ITokenStore)store).InitAsync("user1", "session1");
+        return store;
+    }
+
+    [Fact]
+    public async Task GetAuthenticationHeaderAsync_ThrowsForNullStore() {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => ((ITokenStore)null!).GetAuthenticationHeaderAsync());
+    }
+
+    [Fact]
+    public async Task GetAuthenticationHeaderAsync_ReturnsNull_WhenNoTokenStored() {
+        var store = await InitializedStore();
+        Assert.Null(await store.GetAuthenticationHeaderAsync());
+    }
+
+    [Fact]
+    public async Task GetAuthenticationHeaderAsync_ReturnsBearerHeader() {
+        var store = await InitializedStore(new OAuthTokens("Bearer", "my-access-token", null, null));
+
+        var header = await store.GetAuthenticationHeaderAsync();
+
+        Assert.NotNull(header);
+        Assert.Equal("Bearer", header!.Scheme);
+        Assert.Equal("my-access-token", header.Parameter);
+    }
+
+    [Fact]
+    public async Task GetAuthenticationHeaderAsync_AlwaysUsesBearerScheme_RegardlessOfTokenType() {
+        // The implementation hardcodes "Bearer" and does not forward the TokenType from OAuthTokens.
+        var store = await InitializedStore(new OAuthTokens("mac", "my-access-token", null, null));
+
+        var header = await store.GetAuthenticationHeaderAsync();
+
+        Assert.NotNull(header);
+        Assert.Equal("Bearer", header!.Scheme);
+    }
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/TokenStoreTests.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication.Tests/TokenStoreTests.cs
@@ -1,0 +1,146 @@
+using static Microsoft.Extensions.Options.Options;
+
+namespace IntelligentPlant.IndustrialAppStore.Authentication.Tests;
+
+public class TokenStoreTests {
+
+    private static TestTokenStore CreateStore(TimeProvider? timeProvider = null) {
+        var options = Create(new IndustrialAppStoreAuthenticationOptions { ClientId = "test-client" });
+        return new TestTokenStore(options, new HttpClient(), timeProvider ?? TimeProvider.System);
+    }
+
+    // -------------------------------------------------------------------------
+    // Lifecycle
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Ready_IsFalse_BeforeInit() {
+        Assert.False(CreateStore().Ready);
+    }
+
+    [Fact]
+    public async Task Ready_IsTrue_AfterInit() {
+        var store = CreateStore();
+        await ((ITokenStore)store).InitAsync("user1", "session1");
+        Assert.True(store.Ready);
+    }
+
+    [Fact]
+    public async Task InitAsync_ThrowsForNullUserId() {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => ((ITokenStore)CreateStore()).InitAsync(null!, "session1").AsTask());
+    }
+
+    [Fact]
+    public async Task InitAsync_ThrowsForNullSessionId() {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => ((ITokenStore)CreateStore()).InitAsync("user1", null!).AsTask());
+    }
+
+    [Fact]
+    public async Task InitAsync_ThrowsOnSecondCall() {
+        var store = CreateStore();
+        await ((ITokenStore)store).InitAsync("user1", "session1");
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ((ITokenStore)store).InitAsync("user1", "session1").AsTask());
+    }
+
+    [Fact]
+    public async Task GetTokensAsync_ThrowsIfNotInitialized() {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ((ITokenStore)CreateStore()).GetTokensAsync().AsTask());
+    }
+
+    [Fact]
+    public async Task SaveTokensAsync_ThrowsIfNotInitialized() {
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => ((ITokenStore)CreateStore()).SaveTokensAsync(new OAuthTokens("Bearer", "t", null, null)).AsTask());
+    }
+
+    // -------------------------------------------------------------------------
+    // Token retrieval — expiry logic
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetTokensAsync_ReturnsNull_WhenNoTokenStored() {
+        var store = CreateStore();
+        await ((ITokenStore)store).InitAsync("user1", "session1");
+        Assert.Null(await ((ITokenStore)store).GetTokensAsync());
+    }
+
+    [Fact]
+    public async Task GetTokensAsync_ReturnsNull_WhenAccessTokenIsWhitespace() {
+        // OAuthTokens ctor only guards against null; whitespace is caught by the base class.
+        var store = CreateStore();
+        store.SetTokens(new OAuthTokens("Bearer", "   ", null, null));
+        await ((ITokenStore)store).InitAsync("user1", "session1");
+        Assert.Null(await ((ITokenStore)store).GetTokensAsync());
+    }
+
+    [Fact]
+    public async Task GetTokensAsync_ReturnsToken_WhenNoExpirySet() {
+        var store = CreateStore();
+        store.SetTokens(new OAuthTokens("Bearer", "access-token", null, null));
+        await ((ITokenStore)store).InitAsync("user1", "session1");
+
+        var result = await ((ITokenStore)store).GetTokensAsync();
+
+        Assert.NotNull(result);
+        Assert.Equal("access-token", result.Value.AccessToken);
+    }
+
+    [Fact]
+    public async Task GetTokensAsync_ReturnsToken_WhenNotExpired() {
+        var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var store = CreateStore(new FixedTimeProvider(now));
+        store.SetTokens(new OAuthTokens("Bearer", "access-token", null, now.AddHours(1)));
+        await ((ITokenStore)store).InitAsync("user1", "session1");
+
+        var result = await ((ITokenStore)store).GetTokensAsync();
+
+        Assert.NotNull(result);
+        Assert.Equal("access-token", result.Value.AccessToken);
+    }
+
+    [Fact]
+    public async Task GetTokensAsync_ReturnsNull_WhenExpiredAndNoRefreshToken() {
+        var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var store = CreateStore(new FixedTimeProvider(now));
+        store.SetTokens(new OAuthTokens("Bearer", "access-token", null, now.AddSeconds(-1)));
+        await ((ITokenStore)store).InitAsync("user1", "session1");
+
+        Assert.Null(await ((ITokenStore)store).GetTokensAsync());
+    }
+
+    [Fact]
+    public async Task GetTokensAsync_ReturnsToken_WhenRefreshTokenPresent_AndExpiryBeyondBuffer() {
+        // Token expiring in 60s: even with the 30s early-expiry buffer applied when a refresh
+        // token is present, the token is still considered valid (60 > 30).
+        var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var store = CreateStore(new FixedTimeProvider(now));
+        store.SetTokens(new OAuthTokens("Bearer", "access-token", "refresh-token", now.AddSeconds(60)));
+        await ((ITokenStore)store).InitAsync("user1", "session1");
+
+        var result = await ((ITokenStore)store).GetTokensAsync();
+
+        Assert.NotNull(result);
+        Assert.Equal("access-token", result.Value.AccessToken);
+    }
+
+    [Fact]
+    public async Task GetTokensAsync_ReturnsToken_WhenNoRefreshToken_AndWithinBufferWindow() {
+        // Without a refresh token the 30s buffer is not applied; a token expiring in 20s
+        // is still valid because 20s > 0s.
+        var now = new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var store = CreateStore(new FixedTimeProvider(now));
+        store.SetTokens(new OAuthTokens("Bearer", "access-token", null, now.AddSeconds(20)));
+        await ((ITokenStore)store).InitAsync("user1", "session1");
+
+        var result = await ((ITokenStore)store).GetTokensAsync();
+
+        Assert.NotNull(result);
+        Assert.Equal("access-token", result.Value.AccessToken);
+    }
+
+
+}

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
@@ -95,7 +95,16 @@ namespace Microsoft.Extensions.DependencyInjection {
                     .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler() {
                         EnableMultipleHttp2Connections = true
                     })
-                    .AddStandardResilienceHandler())
+                    .AddStandardResilienceHandler(resilience => {
+                        // Disable per-attempt timeout to prevent spurious retries to remote data sources.
+                        // The API client proxies requests to remote data sources that may not support 
+                        // mid-flight cancellation. With attempt timeout enabled, a timeout would cancel 
+                        // the client-side request and trigger a retry, but the original request to the 
+                        // remote data source would continue running, resulting in duplicate requests and 
+                        // wasted resources. The total request timeout (default 30s) still applies as a 
+                        // safeguard against indefinite hangs.
+                        resilience.AttemptTimeout.Timeout = Timeout.InfiniteTimeSpan;
+                    }))
                 .AddCoreAuthenticationServices()
                 .AddAuthentication(configure)
                 .AddAccessTokenProvider(provider => {

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
@@ -2,14 +2,12 @@
 using IntelligentPlant.IndustrialAppStore.Authentication.Options;
 using IntelligentPlant.IndustrialAppStore.Client;
 using IntelligentPlant.IndustrialAppStore.DependencyInjection;
-
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
-
 using Polly;
 
 namespace Microsoft.Extensions.DependencyInjection {
@@ -100,14 +98,16 @@ namespace Microsoft.Extensions.DependencyInjection {
                     })
                     // Custom resilience pipeline that mirrors AddStandardResilienceHandler but
                     // omits the per-attempt timeout. Per-attempt timeouts are not suitable for this
-                    // use-case since the API client proxies requests to remote data
-                    // sources that may not support mid-flight cancellation: a per-attempt timeout
-                    // would cancel the client-side request and trigger a retry, but the remote
-                    // request would continue running, producing duplicate work. The total request
-                    // timeout (default 30 s) still guards against indefinite hangs.
-                    .AddResilienceHandler("standard", pipeline => {
+                    // use-case since the API client proxies requests to remote data sources that may
+                    // not support mid-flight cancellation: a per-attempt timeout would cancel the
+                    // client-side request and trigger a retry, but the remote request would continue
+                    // running, producing duplicate work. The total request timeout (configurable via
+                    // HttpRequestTimeout; default 30 s) still guards against indefinite hangs.
+                    .AddResilienceHandler("standard", (pipeline, context) => {
+                        var iasOptions = context.ServiceProvider.GetRequiredService<IOptionsMonitor<IndustrialAppStoreAuthenticationOptions>>();
                         pipeline
-                            .AddTimeout(new HttpTimeoutStrategyOptions { Timeout = TimeSpan.FromSeconds(30) })
+                            .AddRateLimiter(new HttpRateLimiterStrategyOptions())
+                            .AddTimeout(new HttpTimeoutStrategyOptions { Timeout = iasOptions.CurrentValue.HttpRequestTimeout })
                             .AddRetry(new HttpRetryStrategyOptions())
                             .AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions());
                     }))

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationExtensions.cs
@@ -7,7 +7,10 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
+
+using Polly;
 
 namespace Microsoft.Extensions.DependencyInjection {
 
@@ -95,15 +98,18 @@ namespace Microsoft.Extensions.DependencyInjection {
                     .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler() {
                         EnableMultipleHttp2Connections = true
                     })
-                    .AddStandardResilienceHandler(resilience => {
-                        // Disable per-attempt timeout to prevent spurious retries to remote data sources.
-                        // The API client proxies requests to remote data sources that may not support 
-                        // mid-flight cancellation. With attempt timeout enabled, a timeout would cancel 
-                        // the client-side request and trigger a retry, but the original request to the 
-                        // remote data source would continue running, resulting in duplicate requests and 
-                        // wasted resources. The total request timeout (default 30s) still applies as a 
-                        // safeguard against indefinite hangs.
-                        resilience.AttemptTimeout.Timeout = Timeout.InfiniteTimeSpan;
+                    // Custom resilience pipeline that mirrors AddStandardResilienceHandler but
+                    // omits the per-attempt timeout. Per-attempt timeouts are not suitable for this
+                    // use-case since the API client proxies requests to remote data
+                    // sources that may not support mid-flight cancellation: a per-attempt timeout
+                    // would cancel the client-side request and trigger a retry, but the remote
+                    // request would continue running, producing duplicate work. The total request
+                    // timeout (default 30 s) still guards against indefinite hangs.
+                    .AddResilienceHandler("standard", pipeline => {
+                        pipeline
+                            .AddTimeout(new HttpTimeoutStrategyOptions { Timeout = TimeSpan.FromSeconds(30) })
+                            .AddRetry(new HttpRetryStrategyOptions())
+                            .AddCircuitBreaker(new HttpCircuitBreakerStrategyOptions());
                     }))
                 .AddCoreAuthenticationServices()
                 .AddAuthentication(configure)

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptions.cs
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IndustrialAppStoreAuthenticationOptions.cs
@@ -1,8 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Security.Claims;
-
 using IntelligentPlant.IndustrialAppStore.Client;
-
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Http;
@@ -97,10 +95,20 @@ namespace IntelligentPlant.IndustrialAppStore.Authentication {
         public bool ShowConsentPrompt { get; set; }
 
         /// <summary>
+        /// The total request timeout applied to HTTP requests made via <see cref="IndustrialAppStoreHttpClient"/>.
+        /// </summary>
+        /// <remarks>
+        ///   This timeout guards against indefinitely-hanging requests. Per-attempt timeouts are
+        ///   not used because requests may be proxied to remote data sources that do not support
+        ///   mid-flight cancellation.
+        /// </remarks>
+        public TimeSpan HttpRequestTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>
         /// The expiry time for the cookie used to store the user's session.
         /// </summary>
         /// <remarks>
-        ///  If <see langword="null"/>, the cookie will use the default expiry period for an 
+        ///  If <see langword="null"/>, the cookie will use the default expiry period for an
         ///  ASP.NET Core authentication cookie.
         /// </remarks>
         public TimeSpan? CookieExpiry { get; set; }

--- a/src/IntelligentPlant.IndustrialAppStore.Authentication/IntelligentPlant.IndustrialAppStore.Authentication.csproj
+++ b/src/IntelligentPlant.IndustrialAppStore.Authentication/IntelligentPlant.IndustrialAppStore.Authentication.csproj
@@ -41,5 +41,6 @@
   <ItemGroup>
     <None Include="PACKAGE_README.md" Pack="true" PackagePath=".\README.md" />
   </ItemGroup>
-  
+
+
 </Project>


### PR DESCRIPTION
Configure the standard resilience handler to set AttemptTimeout.Timeout to Timeout.InfiniteTimeSpan. This prevents per-attempt timeouts from canceling client-side requests and triggering spurious retries to remote data sources that may not support mid-flight cancellation; the total request timeout (default 30s) still applies as a safeguard.