### PR TITLE
Prepare pre-release version

### DIFF
--- a/build/version.json
+++ b/build/version.json
@@ -2,5 +2,5 @@
   "Major": 3,
   "Minor": 5,
   "Patch": 1,
-  "PreRelease": ""
+  "PreRelease": "pre"
 }


### PR DESCRIPTION
Given that this release contains large version jumps in some referenced assemblies (e.g. Microsoft.SemanticKernel.Core 1.48.0 → 1.77.0), we should go through a pre-release cycle to check for runtime issues.